### PR TITLE
#174 bugfix 운영환경에서 multipart/formdata 전송 시 rawpostdataexception 오류 발생

### DIFF
--- a/backend/banner/views/admin.py
+++ b/backend/banner/views/admin.py
@@ -43,7 +43,7 @@ class AdminBannerAPIView(APIView):
         """
 
         link_url = request.data.get('link_url')
-        form = ImageUploadForm(request.POST, request.FILES)
+        banner_image = request.data.get('image')
 
         # URL 유효성 검사
         url_validator = URLValidator()
@@ -52,24 +52,15 @@ class AdminBannerAPIView(APIView):
         except ValidationError:
             return self.error("Invalid URL")
 
-        # 이미지 폼 유효성 검사
-        if form.is_valid():
-            banner_image = form.cleaned_data["image"]
+        if banner_image.size > 2 * 1024 * 1024:
+            return self.error("Picture is too large")
 
-            # 파일 크기 검사
-            if banner_image.size > 2 * 1024 * 1024:
-                return self.error("Picture is too large")
-
-            # 파일 확장자 검사
-            suffix = os.path.splitext(banner_image.name)[-1].lower()
-            if suffix not in [".gif", ".jpg", ".jpeg", ".bmp", ".png"]:
-                return self.error("Unsupported file format")
-
-        else:
-            return self.error("Invalid file content")
+        banner_image_suffix = os.path.splitext(banner_image.name)[-1].lower()
+        if banner_image_suffix not in [".gif", ".jpg", ".jpeg", ".bmp", ".png"]:
+            return self.error("Unsupported file format")
 
         # 배너 이미지 주소를 랜덤으로 생성
-        name = rand_str(10) + suffix
+        name = rand_str(10) + banner_image_suffix
 
         # 배너 이미지 저장
         banner_path = os.path.join(settings.BANNER_DIR, name)

--- a/backend/utils/api/api.py
+++ b/backend/utils/api/api.py
@@ -112,6 +112,8 @@ class APIView(View):
         return request.GET
                 request.data = request.POST.copy()
                 request.data.update(request.FILES)
+                request.data = request.POST.copy()
+                request.data.update(request.FILES)
 
     def response(self, data):
         return self.response_class.response(data)

--- a/backend/utils/api/api.py
+++ b/backend/utils/api/api.py
@@ -97,10 +97,7 @@ class APIView(View):
         #     return {}
         # return request.GET
         if request.method not in ["GET", "DELETE"]:
-            body = request.body
-            content_type = request.META.get("CONTENT_TYPE")
-            if not content_type:
-                raise ValueError("content_type is required")
+            content_type = request.META.get("CONTENT_TYPE", "")
             if content_type.startswith('multipart/form-data'):
                 return request.POST.dict()  # Django already parses multipart data
             for parser in self.request_parsers:
@@ -113,6 +110,8 @@ class APIView(View):
                 return parser.parse(body)
             return {}
         return request.GET
+                request.data = request.POST.copy()
+                request.data.update(request.FILES)
 
     def response(self, data):
         return self.response_class.response(data)

--- a/backend/utils/api/api.py
+++ b/backend/utils/api/api.py
@@ -78,6 +78,24 @@ class APIView(View):
     response_class = JSONResponse
 
     def _get_request_data(self, request):
+        # if request.method not in ["GET", "DELETE"]:
+        #     body = request.body
+        #     content_type = request.META.get("CONTENT_TYPE")
+        #     print(content_type)
+        #     if not content_type:
+        #         raise ValueError("content_type is required")
+        #     for parser in self.request_parsers:
+        #         print(parser)
+        #         if content_type.startswith(parser.content_type):
+        #             break
+        #     # else means the for loop is not interrupted by break
+        #     else:
+        #         print(content_type)
+        #         raise ValueError("unknown content_type '%s'" % content_type)
+        #     if body:
+        #         return parser.parse(body)
+        #     return {}
+        # return request.GET
         if request.method not in ["GET", "DELETE"]:
             body = request.body
             content_type = request.META.get("CONTENT_TYPE")


### PR DESCRIPTION
### 문제 원인
- 모든 *APIView가 상속받고 있는 부모 클래스인 APIView 클래스에서 multipart-formdata를 처리할 때, 요청 body에 먼저 접근한 이후 formdata에 접근하는 로직이 있었습니다.
- 어떤 요청이 들어올 때, request.body에 직접 접근하여 이후 content-type에 따른 요청 처리 분기 시, 각각의 content 데이터에 정상적으로 접근이 안되고 있었습니다.

### 주요 변경사항
- multipart/formdata content-type 처리를 별도로 분리하여 우선적으로 처리하였습니다.
- request.body에 직접 접근하는 대신 request.POST와 request.FILES를 사용하여 스트림 소모 문제를 방지하고 여러 번 접근 가능한 데이터 구조를 만들었습니다.