### PR TITLE
fix: API 엔드 포인트 위치 변경

### DIFF
--- a/backend/contest/urls/oj.py
+++ b/backend/contest/urls/oj.py
@@ -1,13 +1,14 @@
 from django.conf.urls import url
 
 from ..views.oj import ContestAnnouncementListAPI, ContestHistoryListAPI, ContestUnderWayListAPI, \
-    ContestNotStartedListAPI
+    ContestNotStartedListAPI, ContestRankAPI
 from ..views.oj import ContestPasswordVerifyAPI, ContestAccessAPI
 from ..views.oj import ContestListAPI, ContestAPI
 
 urlpatterns = [
     url(r"^contests/?$", ContestListAPI.as_view(), name="contest_list_api"),
     url(r"^contest_history/?$", ContestHistoryListAPI.as_view(), name="contest_history_list_api"),
+    url(r"^contest_rank/?$", ContestRankAPI.as_view(), name="contest_rank_api"),
     url(r"^contest_underway/?$", ContestUnderWayListAPI.as_view(), name="contest_underway_list_api"),
     url(r"^contest_not_started/?$", ContestNotStartedListAPI.as_view(), name="contest_not_started_list_api"),
     url(r"^contest/?$", ContestAPI.as_view(), name="contest_api"),


### PR DESCRIPTION
- 백엔드 내 대회 랭킹 API 엔드포인트가 기본 어드민 주소로 연결되어 있어, 엔드포인트 위치 수정 