### PR TITLE
#237 대회 상세 페이지 UI 변경

### DIFF
--- a/frontend/src/i18n/oj/en-US.js
+++ b/frontend/src/i18n/oj/en-US.js
@@ -75,6 +75,8 @@ export const m = {
   save_as_image: "save as image",
   ACM_Contest_Information:
     "ACM 대회는 제출 결과가 성공 또는 실패로만 구분되며 총점은 표시되지 않습니다.",
+  Contest_Rank: "순위",
+  Contest_Participant: "대회 참가자",
   // ACMHelper.vue
   ACM_Helper: "ACM Helper",
   AC_Time: "문제 해결 시간",

--- a/frontend/src/pages/oj/views/contest/ContestList.vue
+++ b/frontend/src/pages/oj/views/contest/ContestList.vue
@@ -224,12 +224,16 @@ export default {
         name: "contest-history-list",
       });
     },
-    dateFormat(date) {
-      const formattedDate = new Date(date);
+    dateFormat(dateUtc) {
+      const date = new Date(dateUtc);
 
-      const hour = formattedDate.getHours();
-      const min = formattedDate.getMinutes();
-      const sec = formattedDate.getSeconds();
+      const newDate = new Date(
+        date.getTime() - date.getTimezoneOffset() * 60 * 1000
+      );
+
+      const hour = newDate.getHours();
+      const min = newDate.getMinutes();
+      const sec = newDate.getSeconds();
 
       let result = "";
       if (hour > 12) result = "오후 " + (hour - 12) + "시 ";

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -12,8 +12,8 @@
       </div>
       <table v-else class="ACMRankContent">
         <thead>
-          <th style="min-width: 50px">#</th>
-          <th>{{ $t("m.User_User") }}</th>
+          <th style="min-width: 50px">{{ $t("m.Contest_Rank") }}</th>
+          <th>{{ $t("m.Contest_Participant") }}</th>
           <th>
             {{ $t("m.Solved_Problems") }}
           </th>
@@ -205,7 +205,7 @@ export default {
   th {
     color: #7e7e7e;
     font-size: 1.3em;
-    padding: 0px 15px 10px 0px;
+    padding: 0px 7.5px 10px 7.5px;
   }
   td {
     border-top: 1px solid rgba(0, 0, 0, 0.1);

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -151,6 +151,7 @@ export default {
       dataRank.forEach((rank, i) => {
         let info = rank.submission_info;
         Object.keys(info).forEach((problemID) => {
+          if (!dataRank[i][problemID]) return;
           dataRank[i][problemID].ac_time = moment(this.contest.start_time)
             .add(info[problemID].ac_time, "seconds")
             .format();

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -3,15 +3,6 @@
     <div class="ACMRankBox">
       <div class="ACMRankTitle">
         <p>{{ $t("m.Rank") }}</p>
-        <CustomTooltip
-          :content="$t('m.ACM_Contest_Information')"
-          placement="right"
-        >
-          <Icon
-            type="ios-information-outline"
-            style="font-size: 20px; font-weight: 900"
-          ></Icon>
-        </CustomTooltip>
       </div>
       <div
         v-if="!dataRank.length"
@@ -197,9 +188,6 @@ export default {
 }
 .ACMRankTitle {
   position: absolute;
-  display: flex;
-  align-items: center;
-  gap: 12px;
   p {
     text-decoration: none;
     font-size: 24px;

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -2,6 +2,16 @@
   <div class="problemBox">
     <div class="problemTitle">
       <p>{{ $t("m.Problems_List") }}</p>
+      <CustomTooltip
+        v-if="contestRuleType === 'ACM'"
+        :content="$t('m.ACM_Contest_Information')"
+        placement="right"
+      >
+        <Icon
+          type="ios-information-outline"
+          style="font-size: 20px; font-weight: 900"
+        ></Icon>
+      </CustomTooltip>
     </div>
     <div
       v-if="problems.length === 0"
@@ -121,6 +131,9 @@ export default {
   border-radius: 7px;
 }
 .problemTitle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   p {
     text-decoration: none;
     font-size: 24px;

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -9,7 +9,7 @@
       >
         <Icon
           type="ios-information-outline"
-          style="font-size: 20px; font-weight: 900"
+          style="font-size: 16px; font-weight: 900"
         ></Icon>
       </CustomTooltip>
     </div>
@@ -133,7 +133,7 @@ export default {
 .problemTitle {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   p {
     text-decoration: none;
     font-size: 24px;

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -29,7 +29,9 @@
         </th>
         <th class="TableTitle">{{ $t("m.Th_Problem_Title") }}</th>
         <th>{{ $t("m.Th_Problem_Difficulty") }}</th>
-        <th>{{ $t("m.Th_Problem_Total_Score") }}</th>
+        <th v-if="contestRuleType !== 'ACM'">
+          {{ $t("m.Th_Problem_Total_Score") }}
+        </th>
         <th>{{ $t("m.Th_Problem_AC_Rate") }}</th>
       </thead>
       <tbody>
@@ -41,7 +43,7 @@
             {{ problem.title }}
           </td>
           <td>{{ DIFFICULTY_MAP[problem.difficulty].value }}</td>
-          <td>{{ problem.total_score }}</td>
+          <td v-if="contestRuleType !== 'ACM'">{{ problem.total_score }}</td>
           <td>
             {{ getACRate(problem.accepted_number, problem.submission_number) }}
           </td>

--- a/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
@@ -12,8 +12,8 @@
       </div>
       <table v-else class="OIRankContent">
         <thead>
-          <th style="width: 50px">#</th>
-          <th>{{ $t("m.User_User") }}</th>
+          <th style="width: 50px">{{ $t("m.Contest_Rank") }}</th>
+          <th>{{ $t("m.Contest_Participant") }}</th>
           <th>{{ $t("m.Total_Score") }}</th>
           <th v-for="problem in contestProblems">
             <CustomTooltip :content="problem._id" placement="top">
@@ -182,7 +182,7 @@ export default {
   th {
     color: #7e7e7e;
     font-size: 1.3em;
-    padding: 0px 15px 10px 0px;
+    padding: 0px 7.5px 10px 7.5px;
   }
   td {
     border-top: 1px solid rgba(0, 0, 0, 0.1);

--- a/frontend/src/store/modules/contest.js
+++ b/frontend/src/store/modules/contest.js
@@ -81,35 +81,52 @@ const getters = {
     );
   },
   contestStartTime: (state) => {
-    return moment(state.contest.start_time);
+    const date = new Date(state.contest.start_time);
+
+    return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000);
   },
   contestEndTime: (state) => {
-    return moment(state.contest.end_time);
+    const date = new Date(state.contest.end_time);
+
+    return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000);
   },
   countdown: (state, getters) => {
     if (getters.contestStatus === CONTEST_STATUS.NOT_START) {
-      let duration = moment.duration(
-        getters.contestStartTime.diff(state.now, "seconds"),
-        "seconds"
-      );
-      if (duration.days() > 0) return "시작 " + duration.days() + "일 전";
+      let duration = getters.contestStartTime - new Date();
+
+      duration = parseInt(duration / 1000);
+      const sec = duration % 60;
+      duration = parseInt(duration / 60);
+      const min = duration % 60;
+      duration = parseInt(duration / 60);
+      const hours = duration % 24;
+      duration = parseInt(duration / 24);
+      const days = duration;
 
       let result = "";
-      if (duration.hours() > 0) result += duration.hours() + "시간 ";
-      if (duration.minutes() > 0) result += duration.minutes() + "분 ";
-      if (duration.seconds() > 0) result += duration.seconds() + "초";
+      if (days > 0) result += days + "일 ";
+      if (hours > 0) result += hours + "시간 ";
+      if (min > 0) result += min + "분 ";
+      if (sec > 0) result += sec + "초";
 
       return "시작까지 " + result + " 전";
     } else if (getters.contestStatus === CONTEST_STATUS.UNDERWAY) {
-      let duration = moment.duration(
-        getters.contestEndTime.diff(state.now, "seconds"),
-        "seconds"
-      );
+      let duration = getters.contestEndTime - new Date();
+
+      duration = parseInt(duration / 1000);
+      const sec = duration % 60;
+      duration = parseInt(duration / 60);
+      const min = duration % 60;
+      duration = parseInt(duration / 60);
+      const hours = duration % 24;
+      duration = parseInt(duration / 24);
+      const days = duration;
+
       let result = "";
-      if (duration.days() > 0) result += duration.days() + "일 ";
-      if (duration.hours() > 0) result += duration.hours() + "시간 ";
-      if (duration.minutes() > 0) result += duration.minutes() + "분 ";
-      if (duration.seconds() > 0) result += duration.seconds() + "초";
+      if (days > 0) result += days + "일 ";
+      if (hours > 0) result += hours + "시간 ";
+      if (min > 0) result += min + "분 ";
+      if (sec > 0) result += sec + "초";
 
       return "종료까지 " + result + " 전";
     } else {


### PR DESCRIPTION
- close #237 

## 한 일
- 문제 목록 페이지에 ACM 대회 타입 관련 도움말 추가
- 문제 목록 페이지에서 ACM 대회일 때, 총점 삭제
- 랭킹 페이지의 header 변경 (# -> 순위, 일반 사용자 목록 -> 대회 참가자)
- 랭킹 페이지의 api 받아와지지 않는 이슈 확인
- 개요 페이지의 종료 시간구하는 로직 확인