### PR TITLE
#318 Admin페이지에서 문제 리스트 보이지 않는 현상 해결

### DIFF
--- a/frontend/src/pages/admin/views/problem/ProblemList.vue
+++ b/frontend/src/pages/admin/views/problem/ProblemList.vue
@@ -114,6 +114,9 @@
   import utils from '@/utils/utils'
   import AddProblemComponent from './AddPublicProblem.vue'
 
+  // A list of routers which needs problems list
+  const PROBLEM_LIST_ROUTES = ['problem-list', 'contest-problem-list']
+
   export default {
     name: 'ProblemList',
     components: {
@@ -166,26 +169,25 @@
         this.getProblemList(page)
       },
       getProblemList (page = 1) {
-        if (this.contestId) {
-          this.loading = true
-          let funcName = this.routeName === 'problem-list' ? 'getProblemList' : 'getContestProblemList'
-          let params = {
-            limit: this.pageSize,
-            offset: (page - 1) * this.pageSize,
-            keyword: this.keyword,
-            contest_id: this.contestId
-          }
-          api[funcName](params).then(res => {
-            this.loading = false
-            this.total = res.data.data.total
-            for (let problem of res.data.data.results) {
-              problem.isEditing = false
-            }
-            this.problemList = res.data.data.results
-          }, res => {
-            this.loading = false
-          })
+        this.loading = true
+        let funcName = this.routeName === 'problem-list' ? 'getProblemList' : 'getContestProblemList'
+        console.log('this.routeName:', this.routeName)
+        let params = {
+          limit: this.pageSize,
+          offset: (page - 1) * this.pageSize,
+          keyword: this.keyword,
+          contest_id: this.contestId
         }
+        api[funcName](params).then(res => {
+          this.loading = false
+          this.total = res.data.data.total
+          for (let problem of res.data.data.results) {
+            problem.isEditing = false
+          }
+          this.problemList = res.data.data.results
+        }, res => {
+          this.loading = false
+        })
       },
       deleteProblem (id) {
         this.$confirm(this.$t('m.ProblemList_Delete_Problem_Content'), this.$t('m.ProblemList_Delete_Problem_Title'), {
@@ -237,7 +239,11 @@
       '$route' (newVal, oldVal) {
         this.contestId = newVal.params.contestId
         this.routeName = newVal.name
-        this.getProblemList(this.currentPage)
+
+        if (PROBLEM_LIST_ROUTES.includes(this.routeName)) {
+          // Update only when the router requires a problem list
+          this.getProblemList(this.currentPage)
+        }
       },
       'keyword' () {
         this.currentChange()

--- a/frontend/src/pages/admin/views/problem/ProblemList.vue
+++ b/frontend/src/pages/admin/views/problem/ProblemList.vue
@@ -114,7 +114,7 @@
   import utils from '@/utils/utils'
   import AddProblemComponent from './AddPublicProblem.vue'
 
-  // A list of routers which needs problems list
+  // A list of routers which need problems list
   const PROBLEM_LIST_ROUTES = ['problem-list', 'contest-problem-list']
 
   export default {
@@ -240,8 +240,8 @@
         this.contestId = newVal.params.contestId
         this.routeName = newVal.name
 
+        // Update only when the router requires a problem list
         if (PROBLEM_LIST_ROUTES.includes(this.routeName)) {
-          // Update only when the router requires a problem list
           this.getProblemList(this.currentPage)
         }
       },


### PR DESCRIPTION
# Changelog
- Resolve #318 
  - 문제 리스트가 필요한 Route를 `PROBLEM_LIST_ROUTES`에 저장
  - 문제 리스트가 필요한 Route에서만 `getProblemList()`를 호출하도록 변경
  - `getProblemList()`가 Contest ID가 없어도 호출될 수 있도록 변경
    - `problem-list`와 `contest-problem-list`에서 모두 작동할 수 있도록 수정

# Testing
Local 환경에서 테스트

- `문제 목록`탭에서 문제 리스트 확인
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/e00fcbde-5b02-4fd8-b82e-1a12a60e7a31" />

- `대회 > 대회 목록 > 문제` 에서 문제 리스트 확인
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/82b1dbdd-2a91-40ce-aea3-498294e6a6ae" />

- 다른 Admin 컴포넌트 정상 동작 확인

# Ops Impact
N/A

# Version Compatibility
N/A