### PR TITLE
#340 GitHub에 README.md 파일 업로드 구현

### DIFF
--- a/hub/scripts/code-place/upload.js
+++ b/hub/scripts/code-place/upload.js
@@ -1,0 +1,48 @@
+const uploadOneSolveProblemOnGit = async (coplData, cb) => {
+  const token = await getToken();
+  const hook = await getHook();
+  if (isNull(token) || isNull(hook)) {
+    console.error("token or hook is null", token, hook);
+    return;
+  }
+  return upload(
+    token,
+    hook,
+    coplData.readme,
+    coplData.directory,
+    coplData.commitMessage,
+    cb
+  );
+};
+
+const upload = async (
+  token,
+  hook,
+  readmeText,
+  directory,
+  commitMessage,
+  cb
+) => {
+  const git = new GitHub(hook, token);
+  const stats = await getStats();
+  let default_branch = stats.branches[hook];
+  if (isNull(default_branch)) {
+    default_branch = await git.getDefaultBranchOnRepo();
+    stats.branches[hook] = default_branch;
+  }
+  const { refSHA, ref } = await git.getReference(default_branch);
+  const readme = await git.createBlob(readmeText, `${directory}/README.md`);
+  const treeSHA = await git.createTree(refSHA, [readme]);
+  const commitSHA = await git.createCommit(commitMessage, treeSHA, refSHA);
+  await git.updateHead(ref, commitSHA);
+
+  updateObjectDatafromPath(
+    stats.submission,
+    `${hook}/${readme.path}`,
+    readme.sha
+  );
+  await saveStats(stats);
+  if (typeof cb === "function") {
+    cb(stats.branches, directory);
+  }
+};

--- a/hub/scripts/code-place/upload.js
+++ b/hub/scripts/code-place/upload.js
@@ -1,3 +1,15 @@
+/**
+ * Uploads a single solved problem to Git repository
+ *
+ * @async
+ * @param {Object} coplData - Data of the solved problem
+ * @param {string} coplData.readme - README content in markdown format
+ * @param {string} coplData.directory - Directory path where the file will be uploaded
+ * @param {string} coplData.commitMessage - Message for the Git commit
+ * @param {Function} [cb] - Optional callback function to execute after upload
+ * @returns {Promise<void|Object>} - Result of the upload operation or void if token/hook is null
+ * @throws {Error} - If there's an issue during the upload process
+ */
 const uploadOneSolveProblemOnGit = async (coplData, cb) => {
   const token = await getToken();
   const hook = await getHook();
@@ -15,6 +27,19 @@ const uploadOneSolveProblemOnGit = async (coplData, cb) => {
   );
 };
 
+/**
+ * Performs the actual upload to GitHub repository
+ *
+ * @async
+ * @param {string} token - GitHub authentication token
+ * @param {string} hook - GitHub repository reference
+ * @param {string} readmeText - Content for the README.md file
+ * @param {string} directory - Directory path where the file will be uploaded
+ * @param {string} commitMessage - Message for the Git commit
+ * @param {Function} [cb] - Optional callback function to execute after upload
+ * @returns {Promise<void>} - Completes when upload is finished
+ * @throws {Error} - If there's an issue during any GitHub operation
+ */
 const upload = async (
   token,
   hook,
@@ -35,7 +60,6 @@ const upload = async (
   const treeSHA = await git.createTree(refSHA, [readme]);
   const commitSHA = await git.createCommit(commitMessage, treeSHA, refSHA);
   await git.updateHead(ref, commitSHA);
-
   updateObjectDatafromPath(
     stats.submission,
     `${hook}/${readme.path}`,


### PR DESCRIPTION
# Changelog
- GitHub에 `README.md`에서 생성한 파일 GitHub Repository에 커밋 생성

# Testing
- 로컬에서 문제 채점 후 테스트 레포지토리에 커밋되는지 확인
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/1834cc0d-b2df-45e9-8ac9-8e2c4fb126d1" />

# Ops Impact
N/A

# Version Compatibility
N/A