### PR TITLE
#340 Code Place Hub Loader 생성

### DIFF
--- a/hub/scripts/code-place/code_place.js
+++ b/hub/scripts/code-place/code_place.js
@@ -1,0 +1,65 @@
+// Set to true to enable console log
+const debug = false;
+
+let loader;
+
+const startLoader = () => {
+  loader = setInterval(async () => {
+    const enabled = await checkEnable();
+    if (!enabled) stopLoader();
+
+    const submissionStateElem = document.querySelector(".submissionState");
+    if (submissionStateElem === null) return;
+
+    const submissionState = submissionStateElem.textContent.trim();
+
+    if (submissionState === RESULT_CATEGORY.RESULT_ACCEPTED) {
+      stopLoader();
+      log("Accepted problem detected, Starting upload...");
+      const coplData = await parseData();
+      await beginUpload(coplData);
+    }
+  }, 2000);
+};
+
+const stopLoader = () => {
+  clearInterval(loader);
+  loader = null;
+};
+
+const versionUpdate = async () => {
+  log("Start Version Update");
+  const stats = await updateLocalStorageStats();
+  // Update Version
+  stats.version = getVersion();
+  await saveStats(stats);
+  log("stats updated.", stats);
+};
+
+const beginUpload = async (coplData) => {
+  console.log("Begin Upload with data", coplData);
+  if (isNotEmpty(coplData)) {
+    const stats = await getStats();
+    const hook = await getHook();
+
+    const currentVersion = stats.version;
+    if (
+      isNull(currentVersion) ||
+      currentVersion !== getVersion() ||
+      isNull(await getStatsSHAfromPath(hook))
+    ) {
+      await versionUpdate();
+    }
+
+    await uploadOneSolveProblemOnGit(coplData, () => {
+      log("Uploaded complete!");
+    });
+  }
+};
+
+const currentUrl = window.location.href;
+
+if (PROBLEM_URL_REGEX.test(currentUrl)) {
+  log("start loader...");
+  startLoader();
+}

--- a/hub/scripts/code-place/parse.js
+++ b/hub/scripts/code-place/parse.js
@@ -1,5 +1,4 @@
 const FALLBACK_VALUE = "UNKNOWN";
-const CODE_PLACE_URL = "https://code.pusan.ac.kr";
 
 /**
  * Safely retrieves the text content of an element matching the selector

--- a/hub/scripts/code-place/variables.js
+++ b/hub/scripts/code-place/variables.js
@@ -1,0 +1,8 @@
+const RESULT_CATEGORY = {
+  RESULT_ACCEPTED: "Accepted",
+};
+
+// Code Place URL
+const CODE_PLACE_URL = "https://code.pusan.ac.kr";
+// Problem Page URL Regular Expression
+const PROBLEM_URL_REGEX = /code\.pusan\.ac\.kr\/problem/;


### PR DESCRIPTION
# Changelog
- Code Place 문제 페이지에 들어가면 Loader가 2초에 한번씩 Accepted되었는지 확인하는 로직 생성
  - `window.location.href`와 `PROBLEM_URL_REGEX`를 비교해 문제 페이지인지 아닌지 확인
  - ACCEPTED된 문제가 있으면 문제 정보 파싱 후 업로드 시작
- `CODE_PLACE_URL`과 같이 여러 스크립트에서 사용되는 상수 `variables.js`에 정의

# Testing
- 문제 ACCEPT 후 테스트 레포지토리에 잘 커밋되는지 확인
<img width="1543" alt="image" src="https://github.com/user-attachments/assets/834a9ec2-9fad-4694-ba1d-c5b1bb703c7d" />

# Ops Impact
N/A

# Version Compatibility
N/A