### PR TITLE
#350 Code Place Hub의 Loader와 Timer 동기화

### DIFF
--- a/hub/scripts/code-place/code_place.js
+++ b/hub/scripts/code-place/code_place.js
@@ -10,7 +10,7 @@ const SUBMIT_ACCEPTED_WAIT_TIME = 10000; // 10s
 
 // Interval ID for status checking
 let loader = null;
-let isLoaderRunning = false;
+let timer = null;
 
 /**
  * Starts the submission state checking loader
@@ -18,19 +18,18 @@ let isLoaderRunning = false;
  * @returns {void}
  */
 const startLoader = () => {
-  if (isLoaderRunning) {
+  if (loader) {
     log("Loader is already running. Ignoring additional loader.");
     return;
   }
 
-  const timer = setTimeout(() => {
+  timer = setTimeout(() => {
     log(
       `Waited Accepted status for ${SUBMIT_ACCEPTED_WAIT_TIME}ms. Stopping loader.`
     );
     stopLoader();
   }, SUBMIT_ACCEPTED_WAIT_TIME);
 
-  isLoaderRunning = true;
   loader = setInterval(async () => {
     log("Checking Submission Status...");
 
@@ -61,14 +60,21 @@ const startLoader = () => {
 };
 
 /**
- * Stops the submission state checking loader
+ * Clears the interval and timeout for checking submission status
  * @returns {void}
  */
 const stopLoader = () => {
   log("Stopping Loader...");
-  isLoaderRunning = false;
-  clearInterval(loader);
-  loader = null;
+
+  if (loader) {
+    clearInterval(loader);
+    loader = null;
+  }
+
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
 };
 
 /**


### PR DESCRIPTION
# Changelog
- Timer는 제출 상태가 10초동안 바뀌지 않을 경우 종료하기 위한 것인데, Loader와 Timer가 연동되어 있지 않아 제출이 성공해도 Timeout 되는 현상이 있었습니다. 이 PR은 timer와 loader를 함께 시작하고 함께 종료하여 항상 timeout 되는 문제를 해결합니다.

# Testing
- 로컬 테스트

# Ops Impact
N/A

# Version Compatibility
N/A