### PR TITLE
#362 Code Place Hub 인증 시 인증 서버를 통해 Access Token 발급

### DIFF
--- a/hub/scripts/authorize.js
+++ b/hub/scripts/authorize.js
@@ -81,7 +81,6 @@ const localAuth = {
     xhr.addEventListener("readystatechange", () => {
       if (xhr.readyState === 4) {
         if (xhr.status === 200) {
-          console.log("Successfully authenticated.");
           const username = JSON.parse(xhr.responseText).login;
           chrome.runtime.sendMessage({
             closeWebPage: true,

--- a/hub/scripts/authorize.js
+++ b/hub/scripts/authorize.js
@@ -78,9 +78,10 @@ const localAuth = {
     const AUTHENTICATION_URL = "https://api.github.com/user";
 
     const xhr = new XMLHttpRequest();
-    xhr.addEventListener("readystatechange", function () {
+    xhr.addEventListener("readystatechange", () => {
       if (xhr.readyState === 4) {
         if (xhr.status === 200) {
+          console.log("Successfully authenticated.");
           const username = JSON.parse(xhr.responseText).login;
           chrome.runtime.sendMessage({
             closeWebPage: true,

--- a/hub/scripts/background.js
+++ b/hub/scripts/background.js
@@ -40,7 +40,6 @@ function handleMessage(request, sender, sendResponse) {
       chrome.tabs.remove(tab.id);
     });
   }
-  return true;
 }
 
 chrome.runtime.onMessage.addListener(handleMessage);

--- a/hub/scripts/oauth2.js
+++ b/hub/scripts/oauth2.js
@@ -5,11 +5,10 @@ const oAuth2 = {
    */
   init() {
     this.KEY = "CodePlaceHub_token";
-    this.ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+    // TODO: Change ACCESS_TOKEN_URL to the correct one. This is for testing.
+    this.ACCESS_TOKEN_URL = "http://localhost:8081/api/token/issue";
     this.AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
-    // TODO: Store CLIENT_ID and CLIENT_SECRET with more secured way.
-    this.CLIENT_ID = "";
-    this.CLIENT_SECRET = "";
+    this.CLIENT_ID = "Ov23liGMeecEJnH8nRfD"; // Code Place Hub OAuth App ID
     this.REDIRECT_URL = "https://github.com/"; // for example, https://github.com
     this.SCOPES = ["repo"];
   },


### PR DESCRIPTION
# Changelog
- 기존: Chrome Extension에서 OAuth App Secret을 가지고 직접 Github에 Access Token을 발급
- 수정: Chrome Extension은 OAuth App Secret을 모름, 인증 서버에 임시 코드를 포함해 요청을 보내면 인증 서버가 Access Token을 발급

# Testing
로컬 테스트

1. 인증 서버 실행
```
cd hub/auth_server
docker build -t hub_auth_server .
docker run -d -p 8081:80 --name hub_auth_server -e GITHUB_OAUTH_APP_ID=<비밀> -e GITHUB_OAUTH_APP_SECRET=<비밀> hub_auth_server
```
2. Chrome Extension에 로그 출력
<img width="519" alt="image" src="https://github.com/user-attachments/assets/575f6d79-8dd6-4154-ab89-8df80ed7445b" />

<img width="521" alt="image" src="https://github.com/user-attachments/assets/e57922f9-2dc1-41dc-812e-5ce668e18868" />

# Ops Impact
N/A

# Version Compatibility
N/A