### PR TITLE
#353 Code Place Hub 인증 서버 CORS 설정

### DIFF
--- a/hub/auth_server/app/main.py
+++ b/hub/auth_server/app/main.py
@@ -8,12 +8,21 @@ import json
 from typing import Dict, Any
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import httpx
 
 from .config import settings
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://github.com"],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Accept", "Authorization"],
+)
 
 
 class TokenRequest(BaseModel):
@@ -60,7 +69,7 @@ async def exchange_code_for_token(code: str) -> Dict[str, Any]:
         return data
 
 
-@app.post("/token/issue", response_model=TokenResponse)
+@app.post("/api/token/issue", response_model=TokenResponse)
 async def issue_access_token(request: TokenRequest) -> TokenResponse:
     """
     Issue a personal access token (PAT) for GitHub.

--- a/hub/auth_server/app/test_main.py
+++ b/hub/auth_server/app/test_main.py
@@ -11,9 +11,9 @@ def client():
 
 def test_no_code(client):
     """
-    Test the /token/issue endpoint without providing a code.
+    Test the /api/token/issue endpoint without providing a code.
     """
-    response = client.post("/token/issue")
+    response = client.post("/api/token/issue")
     assert response.status_code == 422, "Expected HTTP 422 Unprocessable Entity"
     assert "detail" in response.json(), "Expected error details in response"
 
@@ -27,7 +27,7 @@ def test_successful_token_issue(client):
     mock_client.__aenter__.return_value.post.return_value = mock_response
 
     with mock.patch("httpx.AsyncClient", return_value=mock_client):
-        response = client.post("/token/issue", json={"code": "mock_code"})
+        response = client.post("/api/token/issue", json={"code": "mock_code"})
 
     assert response.status_code == 200, "Expected HTTP 200 OK"
     assert "access_token" in response.json(), "Expected access_token in response"
@@ -43,7 +43,7 @@ def test_github_api_failure(client):
     mock_client.__aenter__.return_value.post.return_value = mock_response
 
     with mock.patch("httpx.AsyncClient", return_value=mock_client):
-        response = client.post("/token/issue", json={"code": "invalid_code"})
+        response = client.post("/api/token/issue", json={"code": "invalid_code"})
 
     assert response.status_code == 400, "Expected HTTP 400 Bad Request"
     assert "detail" in response.json(), "Expected error details in response"
@@ -55,7 +55,7 @@ def test_internal_server_error(client):
     mock_client.__aenter__.return_value.post.side_effect = Exception("Internal Server Error")
 
     with mock.patch("httpx.AsyncClient", return_value=mock_client):
-        response = client.post("/token/issue", json={"code": "mock_code"})
+        response = client.post("/api/token/issue", json={"code": "mock_code"})
 
     assert response.status_code == 500, "Expected HTTP 500 Internal Server Error"
     assert "detail" in response.json(), "Expected error details in response"


### PR DESCRIPTION
# Changelog
- 인증 서버에서 `github.com`에 대한 CORS 허용
  - Chrome Extension이 Github에서 인증을 하고 인증 완료 후 Github 페이지에서 `authorize.js`에 의해 인증 서버로 API 요청을 보내므로 `github.com`에 대한 CORS 허용이 필요함

# Testing
<img width="941" alt="image" src="https://github.com/user-attachments/assets/e5b162e5-53b5-4d6a-adce-92edf83ae67d" />

# Ops Impact
N/A

# Version Compatibility
N/A