### PR TITLE
#367 Code Place Hub 인증 서버 릴리즈 분리

### DIFF
--- a/.github/workflows/ci2develop.yml
+++ b/.github/workflows/ci2develop.yml
@@ -120,31 +120,3 @@ jobs:
           build-args: |
             SERVER_NAME=${{ secrets.DEV_SERVER_NAME }}
             APP_VERSION=${{ github.sha }}-dev
-
-  ci-hub-auth-dev:
-    needs: [detect-changes-by-component]
-    if: ${{ needs.detect-changes-by-component.outputs.hub-auth == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Harbor
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.HARBOR_REGISTRY }}
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./hub/auth_server
-          file: ./hub/auth_server/Dockerfile
-          push: true
-          tags: |
-            ${{ secrets.HARBOR_REGISTRY }}/code-place-dev/hub-auth:${{ github.sha }}-dev
-            ${{ secrets.HARBOR_REGISTRY }}/code-place-dev/hub-auth:latest

--- a/.github/workflows/ci2production-and-release.yml
+++ b/.github/workflows/ci2production-and-release.yml
@@ -172,8 +172,8 @@ jobs:
           file: ./hub/auth_server/Dockerfile
           push: true
           tags: |
-            ${{ secrets.HARBOR_REGISTRY }}/code-place-prod/hub-auth:${{ github.sha }}-prod
-            ${{ secrets.HARBOR_REGISTRY }}/code-place-prod/hub-auth:latest
+            ${{ secrets.HARBOR_REGISTRY }}/code-place-hub/auth-server:${{ github.sha }}
+            ${{ secrets.HARBOR_REGISTRY }}/code-place-hub/auth-server:latest
 
   create-release:
     needs: [check-release-branch, ci-frontend, ci-backend, ci-scheduler]

--- a/deployment/docker-compose.hub.yml
+++ b/deployment/docker-compose.hub.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  auth-server:
+    image: registry.copl-dev.site/code-place-hub/auth-server:latest
+    ports:
+      - "3444:80"
+    env_file:
+      - .env
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        order: stop-first
+      restart_policy:
+        condition: on-failure

--- a/script/deploy-hub-stack.sh
+++ b/script/deploy-hub-stack.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+STACK_NAME="code-place-hub"
+
+sudo docker stack deploy -c ../deployment/docker-compose.hub.yml $STACK_NAME


### PR DESCRIPTION
# Changelog
- Code Place Hub 관련 릴리즈는 Code Place와 분리하였습니다.
- Code Place Hub 릴리즈는 `dev`, `prod` 로 나누지 않고 하나의 버전으로 통일하였습니다. 따라서 release 브랜치가 만들어 지는 경우에만 Code Place Hub 인증 서버 이미지가 업데이트됩니다.
  - 추후 Code Place Hub의 Chrome Extension 배포가 시작되면 합쳐서 하나의 Code Place Hub 릴리즈 파이프라인을 구성할 예정입니다.
- 레지스트리에서 `code-place-dev`, `code-place-prod` 프로젝트와 분리된 `code-place-hub` 프로젝트로 이미지를 푸시하도록 하였습니다.
- 서버에서 Code Place Hub 인증 서버를 스택을 생성하는 스크립트 `deploy-hub-stack.sh`를 추가하였습니다.

# Testing
1. 로컬에서 Docker Swarm으로 Code Place Hub 인증 서버 스택 deploy
```
docker swarm init

docker stack deploy -c docker-compose.hub.yml hub
```

2. dummy request를 보내고 요청 잘 들어오는지 확인
```
docker service logs hub_hub-auth
```
<img width="837" alt="image" src="https://github.com/user-attachments/assets/73e64ede-3815-409b-a64a-264d8f770ca3" />

# Ops Impact
N/A

# Version Compatibility
N/A