### PR TITLE
#355 회원가입 시 부산대학교 웹메일 관련 안내 추가

### DIFF
--- a/frontend/src/pages/oj/views/user/Register.vue
+++ b/frontend/src/pages/oj/views/user/Register.vue
@@ -1,8 +1,12 @@
 <template>
   <div>
     <Form ref="formRegister" :model="formRegister" :rules="ruleRegister">
-      <div class="inputName">
-        부산대학교 웹메일
+      <div class="inputNameWithDescription">
+        <span class="inputName">부산대학교 웹메일</span>
+        <div>
+          <Icon type="ios-information" size="13" color="#7a7a7a"></Icon>
+          <span>부산대학교 웹메일이 없으신가요? <a href="https://zm911.mailplug.com/member/join" class="webMailSignUpLink">가입하기</a></span>
+        </div>
       </div>
       <FormItem prop="pnuWebMail">
         <div class="email-form">
@@ -465,6 +469,15 @@ button:disabled {
   }
   100% {
     opacity: 1;
+  }
+}
+
+.webMailSignUpLink {
+  color: var(--point-color);
+  text-decoration: none;
+
+  &:hover {
+    color: lighten(#32306b, 10%);
   }
 }
 


### PR DESCRIPTION
# Changelog
- 회원가입 시 부산대학교 웹메일이 없는 경우가 간혹 있어서, 쉽게 부산대학교 웹메일 회원가입을 진행할 수 있도록 description을 추가하였습니다.
- 파일 Formatting

# Testing
<img width="408" alt="image" src="https://github.com/user-attachments/assets/3d4e3589-4f22-4b5d-89fc-a9914c05e825" />


# Ops Impact
N/A

# Version Compatibility
N/A