### PR TITLE
#378 Code Place Hub Context Error 수정

### DIFF
--- a/hub/scripts/background.js
+++ b/hub/scripts/background.js
@@ -49,7 +49,9 @@ chrome.runtime.onMessage.addListener(handleMessage);
  * Send message to scripts/code_place/code_place.js
  */
 const handleProblemPageDetection = (tabId, url) => {
-  if (PROBLEM_URL_REGEX.test(url)) {
+  // Check if extension context was invalidated or not and if the URL is valid
+  // For extension context invalidation, check out https://stackoverflow.com/questions/53939205/how-to-avoid-extension-context-invalidated-errors-when-messaging-after-an-exte
+  if (chrome.runtime?.id && PROBLEM_URL_REGEX.test(url)) {
     chrome.tabs.sendMessage(tabId, {
       action: "url_changed_to_problem_detail_page",
       url: url,


### PR DESCRIPTION
# Changelog
- Code Place Hub가 실행될 때 Chrome Context가 제대로 설정되지 않은 경우 Code Place Hub 메인 로직을 실행하지 않고 스킵하도록 수정하였습니다. 
  - 적절한 Context를 설정하기 위해서는 새로고침이 필요한데, 새로고침을 강제로 구현하는 것은 UX 측면에서 단점이 될 것 같아 스킵하도록 설정하였습니다.
  - 이 후, Context가 적절히 설정되지 않았을 때 유저에게 새로고침을 권유하는 로직을 구현할 예정입니다.

# Testing
Code Place Hub를 설치하고 새로고침 않더라도 에러가 발생하지 않는 것 확인

# Ops Impact
N/A

# Version Compatibility
N/A