### PR TITLE
#385 대회 문제 탭에서 전체 문제 개수 표시

### DIFF
--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -2,7 +2,7 @@
   <div class="problemBox">
     <div class="problemTitle">
       <div style="display: flex; align-items: center; gap: 10px">
-        <p>{{ $t("m.Problems_List") }}</p>
+        <p>{{ $t("m.Problems_List") }} ({{ problems.length }})</p>
         <CustomTooltip
           v-if="contestRuleType === 'ACM'"
           :content="$t('m.ACM_Contest_Information')"


### PR DESCRIPTION
# Changelog
- 대회 문제 탭의 Title에서 전체 문제 개수를 추가하였습니다.

# Testing
<img width="1589" alt="image" src="https://github.com/user-attachments/assets/1bfb2251-f33c-4bb9-9970-70dfd84044af" />

# Ops Impact
N/A

# Version Compatibility
N/A