### PR TITLE
#394 문제 Weekly Stats 업데이트 API 생성

### DIFF
--- a/backend/problem/urls/oj.py
+++ b/backend/problem/urls/oj.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from ..views.oj import ProblemTagAPI, ProblemAPI, ContestProblemAPI, PickOneAPI, RecommendProblemAPI, BonusProblemAPI, MostDifficultProblemAPI
+from ..views.oj import ProblemTagAPI, ProblemAPI, ContestProblemAPI, PickOneAPI, RecommendProblemAPI, BonusProblemAPI, MostDifficultProblemAPI, UpdateWeeklyStatsAPI
 
 urlpatterns = [
     url(r"^problem/tags/?$", ProblemTagAPI.as_view(), name="problem_tag_list_api"),
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r"^contest/problem/?$", ContestProblemAPI.as_view(), name="contest_problem_api"),
     url(r"^recommend_problem/?$", RecommendProblemAPI.as_view(), name="recommend_problem_api"),
     url(r"^problem/most_difficult_problem/?$", MostDifficultProblemAPI.as_view(), name="most_difficult_problem_api"),
+    url(r"^problem/update_weekly_stats/?$", UpdateWeeklyStatsAPI.as_view(), name="update_weekly_stats_api"),
 ]

--- a/backend/problem/views/oj.py
+++ b/backend/problem/views/oj.py
@@ -1,15 +1,20 @@
+import logging
 import random
+
 from django.db import transaction
-from django.db.models import F, Q, Count
-from utils.api import APIView
-from account.decorators import check_contest_permission, login_required, scheduler_only
-from ..models import ProblemTag, Problem, ProblemRuleType, get_default_week_info
-from ..serializers import ProblemSerializer, TagSerializer, ProblemSafeSerializer, RecommendBonusProblemSerializer, MostDifficultProblemSerializer
-from contest.models import ContestRuleType
+from django.db.models import Count, F, Q
+from django.http import HttpResponseBadRequest, HttpResponseNotFound
+
+from account.decorators import (check_contest_permission, login_required, scheduler_only)
 from account.models import UserProfile, UserScore
+from contest.models import ContestRuleType
 from submission.models import JudgeStatus, Submission
-from django.http import HttpResponseNotFound, HttpResponseBadRequest
-from utils.constants import ProblemField, Difficulty, Tier
+from utils.api import APIView
+from utils.constants import Difficulty, ProblemField, Tier
+
+from ..models import (Problem, ProblemRuleType, ProblemTag, get_default_week_info)
+from ..serializers import (MostDifficultProblemSerializer, ProblemSafeSerializer, ProblemSerializer,
+                           RecommendBonusProblemSerializer, TagSerializer)
 
 
 class ProblemTagAPI(APIView):
@@ -340,4 +345,5 @@ class UpdateWeeklyStatsAPI(APIView):
 
             return self.success("Weekly stats updated successfully.")
         except Exception as e:
+            logging.error("Error updating weekly stats: %s", e)
             return self.error("Failed to update weekly stats.")

--- a/backend/problem/views/oj.py
+++ b/backend/problem/views/oj.py
@@ -1,8 +1,9 @@
 import random
-from django.db.models import Q, Count
+from django.db import transaction
+from django.db.models import F, Q, Count
 from utils.api import APIView
-from account.decorators import check_contest_permission, login_required
-from ..models import ProblemTag, Problem, ProblemRuleType
+from account.decorators import check_contest_permission, login_required, scheduler_only
+from ..models import ProblemTag, Problem, ProblemRuleType, get_default_week_info
 from ..serializers import ProblemSerializer, TagSerializer, ProblemSafeSerializer, RecommendBonusProblemSerializer, MostDifficultProblemSerializer
 from contest.models import ContestRuleType
 from account.models import UserProfile, UserScore
@@ -309,3 +310,34 @@ class MostDifficultProblemAPI(APIView):
             return HttpResponseNotFound("There is No most difficult problem in last week")
         serializer = MostDifficultProblemSerializer(most_difficult_problem)
         return self.success(serializer.data)
+
+
+class UpdateWeeklyStatsAPI(APIView):
+
+    @scheduler_only
+    def post(self, request):
+        """Update the weekly statistics of problems.
+        
+        This method updates the last week's statistics to the current week,
+        resets the current week's statistics, and identifies the most difficult problem
+        based on the success rate from the last week.
+        It marks the most difficult problem as such and resets the flag for all others.
+        """
+        try:
+            with transaction.atomic():
+                Problem.objects.update(
+                    last_week_info=F('curr_week_info'),
+                    curr_week_info=get_default_week_info(),
+                    is_most_difficult=False,
+                )
+
+                most_difficult_problem = Problem.objects.annotate(
+                    min_success_rate=F('last_week_info__success_rate')).order_by('min_success_rate').first()
+
+                if most_difficult_problem:
+                    most_difficult_problem.is_most_difficult = True
+                    most_difficult_problem.save(update_fields=['is_most_difficult'])
+
+            return self.success("Weekly stats updated successfully.")
+        except Exception as e:
+            return self.error("Failed to update weekly stats.")


### PR DESCRIPTION
# Changelog
- 스케줄러가 일주일에 한번씩 호출할 수 있는 `UpdateWeeklyStatsAPI` API View를 생성하였습니다.
- API 호출 시 모든 문제에 대해 `last_week_info`에 `curr_week_info`를 저장하고 `curr_week_info` 를 초기화하는 로직을 작성하였습니다.
- Problem 유닛테스트에서 커스텀 `display_id`를 가진 문제를 생성하기 위한 `create_problem_with_custom_display_id` staticmethod를 생성하였습니다.
- `UpdateWeeklyStatsAPI`를 테스트하는 코드를 작성하였습니다.

# Testing
- 유닛테스트 커버리지 100%
<img width="973" alt="image" src="https://github.com/user-attachments/assets/7a7782c6-6f48-45fc-9cea-70a3233b31c8" />

# Ops Impact
N/A

# Version Compatibility
N/A