### PR TITLE
#394 Celery 비동기 작업 큐 및 스케줄러 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -12,6 +12,7 @@ develop-eggs/
 dist/
 eggs/
 lib64/
+lib/
 parts/
 sdist/
 var/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV OJ_ENV production
+ENV MODE server
 WORKDIR /app
 
 COPY ./deploy/requirements.txt /app/deploy/

--- a/backend/account/tasks.py
+++ b/backend/account/tasks.py
@@ -1,8 +1,12 @@
 import logging
+from django.db.models import F
 import dramatiq
 
 from options.options import SysOptions
 from utils.shortcuts import send_email, DRAMATIQ_WORKER_ARGS
+
+from oj import celery
+from .models import UserScore
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +24,26 @@ def send_email_async(from_name, to_email, to_name, subject, content):
                    content=content)
     except Exception as e:
         logger.exception(e)
+
+
+@celery.app.task(name='calculate_user_score_basis')
+def calculate_user_score_basis():
+    """Calculate the basis for user scores by resetting the yesterday's score and fluctuation.
+
+    This method updates all users' `yesterday_score` to their total scores
+    and resets their `fluctuation` to 0.
+    """
+    UserScore.objects.update(yesterday_score=F('total_score'), fluctuation=0)
+    logging.info("User scores have been reset successfully")
+
+
+@celery.app.task(name='calculate_user_score_fluctuation')
+def calculate_user_score_fluctuation():
+    """Calculate the fluctuation of user scores.
+
+    This method calculates the fluctuation of each user's score by subtracting
+    their `yesterday_score` from their `total_score`, and updates the `fluctuation`
+    field in the `UserScore` model.
+    """
+    UserScore.objects.update(fluctuation=F('total_score') - F('yesterday_score'))
+    logging.info("User score fluctuations have been calculated successfully")

--- a/backend/deploy/entrypoint.sh
+++ b/backend/deploy/entrypoint.sh
@@ -57,4 +57,10 @@ chown -R server:spj $DATA $APP/dist
 find $DATA/test_case -type d -exec chmod 710 {} \;
 find $DATA/test_case -type f -exec chmod 640 {} \;
 
-exec supervisord -c /app/deploy/supervisord.conf
+if [ "$MODE" = "celery_worker"]; then
+    exec celery -A oj worker --loglevel=info
+elif [ "$MODE" = "celery_beat" ]; then
+    exec celery -A oj beat --loglevel=info
+else
+    exec supervisord -c /app/deploy/supervisord.conf
+fi

--- a/backend/deploy/entrypoint.sh
+++ b/backend/deploy/entrypoint.sh
@@ -57,7 +57,7 @@ chown -R server:spj $DATA $APP/dist
 find $DATA/test_case -type d -exec chmod 710 {} \;
 find $DATA/test_case -type f -exec chmod 640 {} \;
 
-if [ "$MODE" = "celery_worker"]; then
+if [ "$MODE" = "celery_worker" ]; then
     exec celery -A oj worker --loglevel=info
 elif [ "$MODE" = "celery_beat" ]; then
     exec celery -A oj beat --loglevel=info

--- a/backend/deploy/requirements.txt
+++ b/backend/deploy/requirements.txt
@@ -22,3 +22,5 @@ qrcode==7.4.2
 raven==6.10.0
 XlsxWriter==3.1.9
 yapf==0.43.0
+celery==5.5.3
+django-celery-beat==2.8.1

--- a/backend/oj/celery.py
+++ b/backend/oj/celery.py
@@ -1,0 +1,8 @@
+import os
+import celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'oj.settings')
+
+app = celery.Celery('scheduler')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()

--- a/backend/problem/tasks.py
+++ b/backend/problem/tasks.py
@@ -1,0 +1,78 @@
+import logging
+from django.db import transaction
+from django.db.models import F
+from oj import celery
+
+from .models import Problem, get_default_week_info
+from utils.constants import Difficulty
+
+logger = logging.getLogger(__name__)
+
+DIFFICULTY_GROUPS = [
+    [Difficulty.VERYLOW, Difficulty.LOW],
+    [Difficulty.MID],
+    [Difficulty.HIGH, Difficulty.VERYHIGH],
+]
+
+
+@celery.app.task(name='update_weekly_stats')
+def update_weekly_stats():
+    """Update the weekly statistics of problems.
+    
+    This method updates the last week's statistics to the current week,
+    resets the current week's statistics, and identifies the most difficult problem
+    based on the success rate from the last week.
+    It marks the most difficult problem as such and resets the flag for all others.
+    """
+    with transaction.atomic():
+        Problem.objects.update(
+            last_week_info=F('curr_week_info'),
+            curr_week_info=get_default_week_info(),
+            is_most_difficult=False,
+        )
+
+        most_difficult_problem = Problem.objects.annotate(
+            min_success_rate=F('last_week_info__success_rate')).order_by('min_success_rate').first()
+
+        if most_difficult_problem:
+            most_difficult_problem.is_most_difficult = True
+            most_difficult_problem.save(update_fields=['is_most_difficult'])
+
+
+@celery.app.task(name='update_bonus_problem')
+def update_bonus_problem():
+    """Update bonus problems by selecting one problem from each difficulty group.
+
+    This method selects one problem from each difficulty group, ensuring that no two problems
+    belong to the same field. If no problems are found in a difficulty group, it allows field overlap.
+    It updates the selected problems to be marked as bonus problems and resets the bonus status
+    for all other problems.
+    """
+    selected_problem_ids = list()
+    selected_fields = set()
+
+    with transaction.atomic():
+        for difficulty in DIFFICULTY_GROUPS:
+            candidate_problems = Problem.objects.filter(
+                difficulty__in=difficulty,
+                visible=True,
+                contest__isnull=True,
+            ).exclude(is_bonus=True).exclude(field__in=selected_fields)
+
+            # If no problems found in the current difficulty group, Allow field overlap
+            if not candidate_problems:
+                candidate_problems = Problem.objects.filter(
+                    difficulty__in=difficulty,
+                    visible=True,
+                    contest__isnull=True,
+                ).exclude(is_bonus=True)
+
+            # Randomly select one problem from the candidate problems
+            selected_problem = candidate_problems.order_by('?').first()
+
+            if selected_problem:
+                selected_problem_ids.append(selected_problem.id)
+                selected_fields.add(selected_problem.field)
+
+        Problem.objects.filter(is_bonus=True).update(is_bonus=False)
+        Problem.objects.filter(id__in=selected_problem_ids).update(is_bonus=True)

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -16,8 +16,11 @@ services:
     volumes:
       - data_volume:/data:rw
 
-  scheduler:
-    image: registry.copl-dev.site/code-place-dev/scheduler:latest
+  celery-beat:
+    image: registry.copl-dev.site/code-place-dev/backend:latest
+
+  celery-worker:
+    image: registry.copl-dev.site/code-place-dev/backend:latest
 
   oj-judge:
     image: registry.copl-dev.site/code-place-dev/judge-server:1.0.0-beta

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -31,8 +31,25 @@ services:
       restart_policy:
         condition: on-failure
 
-  scheduler:
-    image: registry.copl-dev.site/code-place-prod/scheduler:latest
+  celery-beat:
+    image: registry.copl-dev.site/code-place-prod/backend:latest
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        order: stop-first
+      restart_policy:
+        condition: on-failure
+
+  celery-worker:
+    image: registry.copl-dev.site/code-place-prod/backend:latest
+    deploy:
+      replicas: 1 # NOTE: This should be adjusted based on the workloads
+      update_config:
+        parallelism: 1
+        order: stop-first
+      restart_policy:
+        condition: on-failure
 
   oj-judge:
     image: registry.copl-dev.site/code-place-prod/judge-server:1.0.0-beta
@@ -45,10 +62,10 @@ services:
         condition: on-failure
       resources:
         limits:
-          cpus: '0.50'
+          cpus: "0.50"
           memory: 1GB
         reservations:
-          cpus: '0.10'
+          cpus: "0.10"
           memory: 300M
 
   oj-postgres:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -18,15 +18,26 @@ services:
     environment:
       - JUDGE_SERVER_TOKEN=CHANGE_THIS # secret.key
 
-  scheduler:
+  celery-beat:
     restart: always
     depends_on:
+      - oj-redis
       - oj-postgres
-      - backend
-    volumes:
-      - ../scheduler/logs:/app/logs
     env_file:
       - .env
+    environment:
+      - MODE=celery_beat
+
+  celery-worker:
+    restart: always
+    depends_on:
+      - oj-redis
+      - oj-postgres
+      - backend
+    env_file:
+      - .env
+    environment:
+      - MODE=celery_worker
 
   oj-judge:
     restart: always


### PR DESCRIPTION
# Changelog
- `Celery`를 비동기 작업 및 스케줄링 작업을 구현하였습니다.
- 아래의 기존 로직들을 담당합니다.
  1. 사용자의 00시 기준 점수 업데이트
  2. 사용자의 점수 변동 폭 업데이트 (현재 점수 - 기준 점수)
  3. 한 주 동안의 문제 별 제출 현황, 성공률 업데이트
  4. 한 주 동안의 보너스 문제 업데이트
- 스케줄링을 담당하는 `celery-beat`와 작업 처리를 담당하는 `celery-worker` 컨테이너를 스택에 추가하였습니다.
- Scheduler 컨테이너를 제거하였습니다.

# Testing
- Beat
<img width="594" alt="image" src="https://github.com/user-attachments/assets/39708f14-5da5-412a-aa9f-1ceb532dba0f" />

- Worker
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/3e9e22ad-91e2-4111-b718-761726ac578e" />

- Unit Test Coverage
<img width="845" alt="image" src="https://github.com/user-attachments/assets/517aef4c-903c-4aa3-88ee-c4a733a827bc" />

<img width="925" alt="image" src="https://github.com/user-attachments/assets/eab7c06e-f072-4a38-b739-7ca0f054209a" />

# Ops Impact
N/A

# Version Compatibility
N/A