### PR TITLE
#413 최초 실패 테스트케이스 정보 조회 기능 추가

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -4,14 +4,18 @@
       <pane :size="50">
         <div class="left-pain-wrapper">
           <div class="tab-headers">
-            <div class="tab-header"
+            <div
+              class="tab-header"
               :class="{ active: leftPainActiveTab === 'problem' }"
-              @click="leftPainActiveTab = 'problem'">
+              @click="leftPainActiveTab = 'problem'"
+            >
               문제 설명
             </div>
-            <div class="tab-header"
+            <div
+              class="tab-header"
               :class="{ active: leftPainActiveTab === 'submission' }"
-              @click="leftPainActiveTab = 'submission'">
+              @click="leftPainActiveTab = 'submission'"
+            >
               제출 현황
             </div>
           </div>
@@ -31,50 +35,58 @@
         </div>
       </pane>
       <pane min-size="30" :size="50">
-        <CodeEditorHeader @create-submission="submitCode"
-                          @change-language="changeLanguage"
-                          :problem="problem"
-                          :language.sync="language"
-                          :statusVisible="statusVisible"
-                          :contestID="contestID"
-                          :result="result"
-                          :submissionId="submissionId"
-                          :isSubmitting="submitting"/>
-        <CodeEditor :value.sync="code"
-                        :languages="problem.languages"
-                        :language="language"
-                        :cursorPos.sync="cursorPos"
-                        :theme.sync="theme"
-                        ref="myCm"/>
-        <StickyLnCol :cursorPos="cursorPos"/>
+        <CodeEditorHeader
+          @create-submission="submitCode"
+          @change-language="changeLanguage"
+          :problem="problem"
+          :language.sync="language"
+          :statusVisible="statusVisible"
+          :contestID="contestID"
+          :result="result"
+          :submissionId="submissionId"
+          :isSubmitting="submitting"
+        />
+        <CodeEditor
+          :value.sync="code"
+          :languages="problem.languages"
+          :language="language"
+          :cursorPos.sync="cursorPos"
+          :theme.sync="theme"
+          ref="myCm"
+        />
+        <StickyLnCol :cursorPos="cursorPos" />
       </pane>
     </splitpanes>
   </div>
 </template>
 
 <script>
-import {mapGetters, mapActions} from 'vuex'
-import {types} from '../../../../../store'
-import storage from '@/utils/storage'
-import {FormMixin} from '@oj/components/mixins'
-import {JUDGE_STATUS, CONTEST_STATUS, buildProblemCodeKey} from '@/utils/constants'
-import api from '@oj/api'
-import {Pane, Splitpanes} from "splitpanes";
-import 'splitpanes/dist/splitpanes.css'
+import { mapGetters, mapActions } from "vuex";
+import { types } from "../../../../../store";
+import storage from "@/utils/storage";
+import { FormMixin } from "@oj/components/mixins";
+import {
+  JUDGE_STATUS,
+  CONTEST_STATUS,
+  buildProblemCodeKey,
+} from "@/utils/constants";
+import api from "@oj/api";
+import { Pane, Splitpanes } from "splitpanes";
+import "splitpanes/dist/splitpanes.css";
 import FieldCategoryBox from "../../../components/FieldCategoryBox.vue";
 import CustomIconBtn from "../../../components/buttons/CustomIconBtn.vue";
-import {DIFFICULTY_MAP, FIELD_MAP} from "../../../../../utils/constants";
+import { DIFFICULTY_MAP, FIELD_MAP } from "../../../../../utils/constants";
 import CodeEditorHeader from "./problemSolvingComponent/CodeEditorHeader.vue";
 import SubmissionStatus from "./problemSolvingComponent/SubmissionStatus.vue";
 import ProblemDetailFlexibleContainer from "./problemSolvingComponent/ProblemDetailFlexibleContainer.vue";
 import StickyLnCol from "./problemSolvingComponent/StickyLnCol.vue";
-import CodeEditor from "./problemSolvingComponent/CodeEditor.vue"
-import SubmissionList from './problemSolvingComponent/SubmissionList.vue'
+import CodeEditor from "./problemSolvingComponent/CodeEditor.vue";
+import SubmissionList from "./problemSolvingComponent/SubmissionList.vue";
 
-const filtedStatus = ['-1', '-2', '0', '1', '2', '3', '4', '8']
+const filtedStatus = ["-1", "-2", "0", "1", "2", "3", "4", "8"];
 
 export default {
-  name: 'Problem',
+  name: "Problem",
   components: {
     StickyLnCol,
     CodeEditor,
@@ -85,133 +97,145 @@ export default {
     CustomIconBtn,
     FieldCategoryBox,
     Splitpanes,
-    Pane
+    Pane,
   },
   mixins: [FormMixin],
   data() {
     return {
       cursorPos: {
         ln: 0,
-        ch: 0
+        ch: 0,
       },
       statusVisible: false,
       captchaRequired: false,
       graphVisible: false,
       submissionExists: false,
-      captchaCode: '',
-      captchaSrc: '',
-      contestID: '',
-      problemID: '',
+      captchaCode: "",
+      captchaSrc: "",
+      contestID: "",
+      problemID: "",
       submitting: false,
-      code: '',
-      language: 'C++',
+      code: "",
+      language: "C++",
       languages: {
         type: Array,
         default: () => {
-          return ['C', 'C++', 'Java', 'Python3']
-        }
+          return ["C", "C++", "Java", "Python3"];
+        },
       },
       theme: false,
-      submissionId: '',
+      submissionId: "",
       submitted: false,
       result: {
-        result: 9
+        result: 9,
       },
       problem: {
-        title: '',
-        description: '',
-        hint: '',
-        my_status: '',
+        title: "",
+        description: "",
+        hint: "",
+        my_status: "",
         template: {},
         languages: [],
         created_by: {
-          username: ''
+          username: "",
         },
-        difficulty: '',
+        difficulty: "",
         tags: [],
-        io_mode: {'io_mode': 'Standard IO'}
+        io_mode: { io_mode: "Standard IO" },
       },
       submission: {
-        result: '0',
-        code: '',
+        result: "0",
+        code: "",
         info: {
-          data: []
+          data: [],
         },
         statistic_info: {
-          time_cost: '',
-          memory_cost: ''
-        }
+          time_cost: "",
+          memory_cost: "",
+        },
       },
       dropdown: {
         openFieldDropdown: false,
-        openCategoryDropdown: false
+        openCategoryDropdown: false,
       },
       modalCheck: false,
-      leftPainActiveTab: 'problem',
-      rightPainActiveTab: 'editor',
-    }
+      leftPainActiveTab: "problem",
+      rightPainActiveTab: "editor",
+    };
   },
   beforeRouteEnter(to, from, next) {
-    let problemCode = storage.get(buildProblemCodeKey(to.params.problemID, to.params.contestID))
-    let psSettings = storage.get("ProblemSolvingSettings")
+    let problemCode = storage.get(
+      buildProblemCodeKey(to.params.problemID, to.params.contestID)
+    );
+    let psSettings = storage.get("ProblemSolvingSettings");
     if (psSettings) {
-      next(vm => {
-        vm.theme = psSettings.theme
-      })
+      next((vm) => {
+        vm.theme = psSettings.theme;
+      });
     } else {
-      next()
+      next();
     }
     if (problemCode) {
-      next(vm => {
-        vm.language = problemCode.language
-        vm.code = problemCode.code
-      })
+      next((vm) => {
+        vm.language = problemCode.language;
+        vm.code = problemCode.code;
+      });
     } else {
-      next()
+      next();
     }
   },
   mounted() {
-    this.$store.commit(types.CHANGE_CONTEST_ITEM_VISIBLE, {menu: false})
-    this.init()
-    window.addEventListener('beforeunload', this.unLoadEvent);
+    this.$store.commit(types.CHANGE_CONTEST_ITEM_VISIBLE, { menu: false });
+    this.init();
+    window.addEventListener("beforeunload", this.unLoadEvent);
   },
   beforeUnmount() {
-    window.removeEventListener('beforeunload', this.unLoadEvent);
+    window.removeEventListener("beforeunload", this.unLoadEvent);
   },
   destroyed() {
-    this.changeProblemSolvingState(false)
+    this.changeProblemSolvingState(false);
   },
   methods: {
-    ...mapActions(['changeDomTitle', 'changeProblemSolvingState', 'changeProblemSolvingTheme']),
+    ...mapActions([
+      "changeDomTitle",
+      "changeProblemSolvingState",
+      "changeProblemSolvingTheme",
+    ]),
     init() {
-      this.changeProblemSolvingState(true)
-      this.$Loading.start()
-      this.contestID = this.$route.params.contestID
-      this.problemID = this.$route.params.problemID
-      let func = this.$route.name === 'problem-details' ? 'getProblem' : 'getContestProblem'
-      api[func](this.problemID, this.contestID).then(res => {
-        this.$Loading.finish()
-        let problem = res.data.data
-        this.changeDomTitle({title: problem.title})
-        api.submissionExists(problem.id).then(res => {
-          this.submissionExists = res.data.data
-        })
-        problem.languages = problem.languages.sort()
-        this.problem = problem
+      this.changeProblemSolvingState(true);
+      this.$Loading.start();
+      this.contestID = this.$route.params.contestID;
+      this.problemID = this.$route.params.problemID;
+      let func =
+        this.$route.name === "problem-details"
+          ? "getProblem"
+          : "getContestProblem";
+      api[func](this.problemID, this.contestID).then(
+        (res) => {
+          this.$Loading.finish();
+          let problem = res.data.data;
+          this.changeDomTitle({ title: problem.title });
+          api.submissionExists(problem.id).then((res) => {
+            this.submissionExists = res.data.data;
+          });
+          problem.languages = problem.languages.sort();
+          this.problem = problem;
 
-        if (this.code !== '') {
-          return
+          if (this.code !== "") {
+            return;
+          }
+          // try to load problem template
+          this.language = this.problem.languages[0];
+          let template = this.problem.template;
+          if (template && template[this.language]) {
+            this.code = template[this.language];
+          }
+          this.problem.difficulty = problem.difficulty;
+        },
+        () => {
+          this.$Loading.error();
         }
-        // try to load problem template
-        this.language = this.problem.languages[0]
-        let template = this.problem.template
-        if (template && template[this.language]) {
-          this.code = template[this.language]
-        }
-        this.problem.difficulty = problem.difficulty
-      }, () => {
-        this.$Loading.error()
-      })
+      );
     },
     unLoadEvent: function (event) {
       if (this.isLeaveSite) return;
@@ -219,178 +243,201 @@ export default {
       storage.set(buildProblemCodeKey(this.problem._id, this.contestID), {
         code: this.code,
         language: this.language,
-      })
+      });
 
       storage.set("ProblemSolvingSettings", {
         theme: this.theme,
-      })
+      });
 
       event.preventDefault();
-      event.returnValue = '';
+      event.returnValue = "";
     },
     changeLanguage(newLang) {
       if (this.problem.template[newLang]) {
-        if (this.code.trim() === '') {
-          this.code = this.problem.template[newLang]
+        if (this.code.trim() === "") {
+          this.code = this.problem.template[newLang];
         }
       }
-      this.language = newLang
-      this.$refs.myCm.onLangChange(newLang)
+      this.language = newLang;
+      this.$refs.myCm.onLangChange(newLang);
     },
     modalOpen() {
-      this.modalCheck = !this.modalCheck
+      this.modalCheck = !this.modalCheck;
     },
     handleRoute(route) {
-      this.$router.push(route)
+      this.$router.push(route);
     },
     check() {
-      alert(this.code)
+      alert(this.code);
     },
     onChangeTheme(newTheme) {
-      this.theme = newTheme
+      this.theme = newTheme;
     },
     checkSubmissionStatus() {
       // 使用setTimeout避免一些问题
       if (this.refreshStatus) {
         // 如果之前的提交状态检查还没有停止,则停止,否则将会失去timeout的引用造成无限请求
-        clearTimeout(this.refreshStatus)
+        clearTimeout(this.refreshStatus);
       }
       const checkStatus = () => {
-        let id = this.submissionId
-        api.getSubmission(id).then(res => {
-          this.result = res.data.data
-          if (Object.keys(res.data.data.statistic_info).length !== 0) {
-            this.submitting = false
-            this.submitted = false
-            clearTimeout(this.refreshStatus)
-            this.init()
-          } else {
-            this.refreshStatus = setTimeout(checkStatus, 2000)
+        let id = this.submissionId;
+        api.getSubmission(id).then(
+          (res) => {
+            this.result = res.data.data;
+            if (Object.keys(res.data.data.statistic_info).length !== 0) {
+              this.submitting = false;
+              this.submitted = false;
+              clearTimeout(this.refreshStatus);
+              this.init();
+            } else {
+              this.refreshStatus = setTimeout(checkStatus, 2000);
+            }
+          },
+          (res) => {
+            this.submitting = false;
+            clearTimeout(this.refreshStatus);
           }
-        }, res => {
-          this.submitting = false
-          clearTimeout(this.refreshStatus)
-        })
-      }
-      this.refreshStatus = setTimeout(checkStatus, 2000)
+        );
+      };
+      this.refreshStatus = setTimeout(checkStatus, 2000);
     },
     submitCode() {
-      if (this.code.trim() === '') {
-        this.$error(this.$i18n.t('m.Code_can_not_be_empty'))
-        return
+      if (this.code.trim() === "") {
+        this.$error(this.$i18n.t("m.Code_can_not_be_empty"));
+        return;
       }
-      this.submissionId = ''
-      this.result = {result: 9}
-      this.submitting = true
+      this.submissionId = "";
+      this.result = { result: 9 };
+      this.submitting = true;
       let data = {
         problem_id: this.problem.id,
         language: this.language,
         code: this.code,
-        contest_id: this.contestID
-      }
+        contest_id: this.contestID,
+      };
       if (this.captchaRequired) {
-        data.captcha = this.captchaCode
+        data.captcha = this.captchaCode;
       }
       const submitFunc = (data, detailsVisible) => {
-        this.statusVisible = true
-        api.submitCode(data).then(res => {
-          this.submissionId = res.data.data && res.data.data.submission_id
-          // 定时检查状态
-          this.submitting = false
-          this.submissionExists = true
-          if (!detailsVisible) {
-            this.$Modal.success({
-              title: this.$i18n.t('m.Success'),
-              content: this.$i18n.t('m.Submit_code_successfully')
-            })
-            return
+        this.statusVisible = true;
+        api.submitCode(data).then(
+          (res) => {
+            this.submissionId = res.data.data && res.data.data.submission_id;
+            // 定时检查状态
+            this.submitting = false;
+            this.submissionExists = true;
+            if (!detailsVisible) {
+              this.$Modal.success({
+                title: this.$i18n.t("m.Success"),
+                content: this.$i18n.t("m.Submit_code_successfully"),
+              });
+              return;
+            }
+            this.submitted = true;
+            this.checkSubmissionStatus();
+          },
+          (res) => {
+            this.getCaptchaSrc();
+            if (res.data.data.startsWith("Captcha is required")) {
+              this.captchaRequired = true;
+            }
+            this.submitting = false;
+            this.statusVisible = false;
           }
-          this.submitted = true
-          this.checkSubmissionStatus()
-        }, res => {
-          this.getCaptchaSrc()
-          if (res.data.data.startsWith('Captcha is required')) {
-            this.captchaRequired = true
-          }
-          this.submitting = false
-          this.statusVisible = false
-        })
-      }
+        );
+      };
 
-      if (this.contestRuleType === 'OI' && !this.OIContestRealTimePermission) {
+      if (this.contestRuleType === "OI" && !this.OIContestRealTimePermission) {
         if (this.submissionExists) {
           this.$Modal.confirm({
-            title: '',
-            content: '<h3>' + this.$i18n.t('m.You_have_submission_in_this_problem_sure_to_cover_it') + '<h3>',
+            title: "",
+            content:
+              "<h3>" +
+              this.$i18n.t(
+                "m.You_have_submission_in_this_problem_sure_to_cover_it"
+              ) +
+              "<h3>",
             onOk: () => {
               // 暂时解决对话框与后面提示对话框冲突的问题(否则一闪而过）
               setTimeout(() => {
-                submitFunc(data, false)
-              }, 1000)
+                submitFunc(data, false);
+              }, 1000);
             },
             onCancel: () => {
-              this.submitting = false
-            }
-          })
+              this.submitting = false;
+            },
+          });
         } else {
-          submitFunc(data, false)
+          submitFunc(data, false);
         }
       } else {
-        submitFunc(data, true)
+        submitFunc(data, true);
       }
     },
   },
   computed: {
     FIELD_MAP() {
-      return FIELD_MAP
+      return FIELD_MAP;
     },
     DIFFICULTY_MAP() {
-      return DIFFICULTY_MAP
+      return DIFFICULTY_MAP;
     },
-    ...mapGetters(['problemSubmitDisabled', 'contestRuleType', 'OIContestRealTimePermission', 'contestStatus', 'isDarkMode']),
+    ...mapGetters([
+      "problemSubmitDisabled",
+      "contestRuleType",
+      "OIContestRealTimePermission",
+      "contestStatus",
+      "isDarkMode",
+    ]),
     contest() {
-      return this.$store.state.contest.contest
+      return this.$store.state.contest.contest;
     },
     contestEnded() {
-      return this.contestStatus === CONTEST_STATUS.ENDED
+      return this.contestStatus === CONTEST_STATUS.ENDED;
     },
     submissionStatus() {
       return {
-        text: JUDGE_STATUS[this.result.result]['name'],
-        color: JUDGE_STATUS[this.result.result]['color']
-      }
+        text: JUDGE_STATUS[this.result.result]["name"],
+        color: JUDGE_STATUS[this.result.result]["color"],
+      };
     },
     submissionRoute() {
       if (this.contestID) {
-        return {name: 'contest-submission-list', query: {problemID: this.problemID}}
+        return {
+          name: "contest-submission-list",
+          query: { problemID: this.problemID },
+        };
       } else {
-        return {name: 'submission-list', query: {problemID: this.problemID}}
+        return {
+          name: "submission-list",
+          query: { problemID: this.problemID },
+        };
       }
-    }
+    },
   },
   beforeRouteLeave(to, from, next) {
-    clearInterval(this.refreshStatus)
-    this.$store.commit(types.CHANGE_CONTEST_ITEM_VISIBLE, {menu: true})
+    clearInterval(this.refreshStatus);
+    this.$store.commit(types.CHANGE_CONTEST_ITEM_VISIBLE, { menu: true });
     storage.set(buildProblemCodeKey(this.problem._id, from.params.contestID), {
       code: this.code,
       language: this.language,
-    })
+    });
     storage.set("ProblemSolvingSettings", {
       theme: this.theme,
-    })
-    next()
+    });
+    next();
   },
   watch: {
-    '$route'() {
-      this.init()
+    $route() {
+      this.init();
     },
     isDarkMode(value) {
-      let customTheme = value ? 'ayu-mirage' : 'github-light'
-      this.$refs.myCm.toggleTheme(customTheme)
-      this.theme = value
-    }
-  }
-}
+      let customTheme = value ? "ayu-mirage" : "github-light";
+      this.$refs.myCm.toggleTheme(customTheme);
+      this.theme = value;
+    },
+  },
+};
 </script>
 
 <style lang="less">
@@ -407,7 +454,6 @@ export default {
     flex: none;
     width: 220px;
   }
-
 }
 
 #submit-code {
@@ -441,7 +487,7 @@ export default {
 }
 
 .splitpanes--vertical > .splitpanes__splitter {
-  min-width: 4px!important;
+  min-width: 4px !important;
   margin-top: 350px;
   margin-bottom: 350px;
   align-items: center;
@@ -499,5 +545,4 @@ export default {
   border: 1px solid var(--border-color);
   border-radius: 0 7px 7px 7px;
 }
-
 </style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
@@ -16,16 +16,16 @@ import "highlight.js/styles/atom-one-dark.css";
  */
 export default {
   name: "CodeHighlight",
-  
+
   props: {
     /**
      * 컴포넌트 타입
      * @type {String}
      * @default "code"
-     * @description "code" - 일반 코드 하이라이팅, "error" - 에러 메시지 표시 (하이라이팅 없음)
+     * @description "code" - 일반 코드 하이라이팅, "error" - 에러 메시지 표시 (하이라이팅 없음), "plaintext" - 일반 텍스트 표시
      */
     type: { type: String, default: "code" },
-    
+
     /**
      * 표시할 코드 내용
      * @type {String}
@@ -33,7 +33,7 @@ export default {
      * @description 하이라이팅할 코드 문자열
      */
     code: { type: String, required: true },
-    
+
     /**
      * 프로그래밍 언어 타입
      * @type {String}
@@ -41,7 +41,7 @@ export default {
      * @description highlight.js에서 지원하는 언어 코드 (예: javascript, python, css 등)
      */
     language: { type: String, default: "plaintext" },
-    
+
     /**
      * 테마 설정
      * @type {Boolean}
@@ -50,7 +50,7 @@ export default {
      */
     theme: { type: Boolean, default: false },
   },
-  
+
   computed: {
     /**
      * 하이라이팅된 코드 HTML 반환
@@ -59,12 +59,12 @@ export default {
     highlightedCode() {
       // 코드가 없으면 빈 문자열 반환
       if (!this.code) return "";
-      
+
       // 에러 타입인 경우 하이라이팅 없이 원본 코드 반환
-      if (this.type === "error") {
+      if (this.type !== "code") {
         return this.code;
       }
-      
+
       try {
         return hljs.highlight(this.language, this.code).value;
       } catch (e) {
@@ -72,7 +72,7 @@ export default {
         return hljs.highlightAuto(this.code).value;
       }
     },
-    
+
     /**
      * 코드 태그에 적용할 CSS 클래스 반환
      * @returns {String} hljs 및 언어별 클래스명
@@ -80,7 +80,7 @@ export default {
     languageClass() {
       return "hljs " + (this.language ? "language-" + this.language : "");
     },
-    
+
     /**
      * 테마 및 타입에 따른 CSS 클래스 반환
      * @returns {String} 테마 클래스 및 에러 클래스 조합
@@ -88,20 +88,19 @@ export default {
     themeClass() {
       // 기본 테마 클래스 설정 (다크/라이트)
       let themeClass = this.theme ? "dark-theme" : "light-theme";
-      
+
       // 에러 타입인 경우 에러 스타일 클래스 추가
       if (this.type === "error") {
         themeClass += " error-info";
       }
-      
+
       return themeClass;
-    }
+    },
   },
 };
 </script>
 
 <style scoped>
-/* 다크 테마 CSS 변수 */
 .dark-theme {
   --dropdown-bg: #1e1e1e;
   --dropdown-text: #d4d4d4;
@@ -111,7 +110,6 @@ export default {
   --error-border: #7f1d1d;
 }
 
-/* 라이트 테마 CSS 변수 */
 .light-theme {
   --dropdown-bg: #ffffff;
   --dropdown-text: #1f2937;
@@ -121,22 +119,20 @@ export default {
   --error-border: #fecaca;
 }
 
-/* 에러 메시지 스타일 */
 .error-info {
   background-color: var(--error-bg) !important;
   color: var(--error-text) !important;
   border: 1px solid var(--error-border) !important;
 }
 
-/* 코드 하이라이팅 래퍼 컨테이너 스타일 */
 .code-highlight-wrapper {
   margin: 0;
   padding: 16px;
   border-radius: 8px;
   font-size: 14px;
-  font-family: "Fira Code", "JetBrains Mono", "Menlo", "Monaco", "Consolas", monospace;
-  white-space: pre-line;
-  overflow-x: auto;
+  font-family: "Fira Code", "JetBrains Mono", "Menlo", "Monaco", "Consolas",
+    monospace;
+  white-space: pre;
   background-color: var(--dropdown-bg);
   color: var(--dropdown-text);
   border: 1px solid var(--border-color);
@@ -148,7 +144,6 @@ export default {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-/* 코드 태그 기본 스타일 초기화 */
 code {
   background: unset;
   color: inherit;

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="submission-error-dropdown">
     <!-- 에러 메시지 섹션 -->
-    <div>
+    <div class="error-message">
       <p class="sub-title">에러 메시지</p>
       <CodeHighlight
         type="error"
@@ -102,6 +102,14 @@ export default {
   margin-bottom: 8px;
 }
 
+.error-message {
+  /deep/ .code-highlight-wrapper {
+    max-width: 100%;
+    max-height: 300px;
+    overflow: auto;
+  }
+}
+
 .failed-tc-header {
   display: flex;
   align-items: center;
@@ -113,7 +121,7 @@ export default {
 .testcase-info {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 16px;
 
   p {
@@ -127,11 +135,14 @@ export default {
 .testcase-output {
   flex: 1;
   max-width: 50%;
-}
+  display: flex;
+  flex-direction: column;
 
-/deep/ .code-highlight-wrapper {
-  max-width: 100%;
-  max-height: 300px;
-  overflow: auto;
+  /deep/ .code-highlight-wrapper {
+    flex: 1;
+    max-width: 100%;
+    max-height: 300px;
+    overflow: auto;
+  }
 }
 </style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="submission-error-dropdown">
+    <!-- 에러 메시지 섹션 -->
     <div>
       <p class="sub-title">에러 메시지</p>
       <CodeHighlight
@@ -8,6 +9,39 @@
         :theme.sync="theme"
       />
     </div>
+
+    <!-- 테스트케이스 정보 섹션 -->
+    <div v-if="hasFailedTestCase">
+      <div class="failed-tc-header">
+        <p>최초 실패 케이스</p>
+        <CustomTooltip
+          content="테스트케이스 중 최초로 실패한 케이스의 입력값과 기대값입니다."
+          placement="right"
+        >
+          <Icon type="ios-information" />
+        </CustomTooltip>
+      </div>
+      <div class="testcase-info">
+        <div class="testcase-input">
+          <p>입력값</p>
+          <CodeHighlight
+            type="plaintext"
+            :code="submission.first_failed_tc_io.input || ''"
+            :theme.sync="theme"
+          />
+        </div>
+        <div class="testcase-output">
+          <p>기대값</p>
+          <CodeHighlight
+            type="plaintext"
+            :code="submission.first_failed_tc_io.output || ''"
+            :theme.sync="theme"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- 제출 코드 섹션 -->
     <div>
       <p class="sub-title">제출 코드</p>
       <CodeHighlight
@@ -22,20 +56,29 @@
 
 <script>
 import CodeHighlight from "./CodeHighlight.vue";
+import CustomTooltip from "@oj/components/CustomTooltip";
 import { HIGHLIGHT_JS_LANGUAGES } from "../../../../../../utils/constants";
 
 export default {
   name: "SubmissionErrorDropdown",
   components: {
     CodeHighlight,
+    CustomTooltip,
   },
   props: {
     submission: {
       type: Object,
+      required: true,
     },
     theme: {
       type: Boolean,
-      default: false, // Default to light theme
+      default: false,
+    },
+  },
+  computed: {
+    hasFailedTestCase() {
+      const tcInfo = this.submission.first_failed_tc_io;
+      return tcInfo && tcInfo.input && tcInfo.output;
     },
   },
   methods: {
@@ -53,35 +96,42 @@ export default {
   gap: 24px;
 }
 
-.error-info {
-  padding: 10px;
-  background-color: var(--error-message-bg);
-  color: var(--error-message-text);
-  border-radius: 6px;
-  font-family: "Fira Mono", "Menlo", "Consolas", monospace;
-  font-size: 13px;
-  white-space: pre-line;
-  word-break: break-all;
-  border: 1px solid var(--dropdown-border);
-  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.08);
-}
-
-.submitted-code {
-  padding: 10px;
-  background-color: var(--dropdown-bg);
-  color: var(--text-color);
-  font-size: 13px;
-  border-radius: 5px;
-  font-family: monospace;
-  white-space: pre-line;
-  word-break: break-all;
-  border: 1px solid var(--dropdown-border);
-  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.08);
-}
-
 .sub-title {
   font-size: 14px;
   font-weight: bold;
   margin-bottom: 8px;
+}
+
+.failed-tc-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+  font-weight: bold;
+  gap: 8px;
+}
+
+.testcase-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+
+  p {
+    font-size: 13px;
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+}
+
+.testcase-input,
+.testcase-output {
+  flex: 1;
+  max-width: 50%;
+}
+
+/deep/ .code-highlight-wrapper {
+  max-width: 100%;
+  max-height: 300px;
+  overflow: auto;
 }
 </style>


### PR DESCRIPTION
# Changelog
- `CodeHighlight` 컴포넌트에 일반 텍스트를 표시하는 type인 `plaintext`를 추가하였습니다.
- `ErrorDropdown` 컴포넌트에 최초 테스트케이스의 입력값과 기대값 출력을 추가하였습니다.
- `CodeHighlight`를 사용할 때 max-width와 max-height를 설정하고, (overflow = scroll) 로 설정하였습니다.

# Testing
- 최초 테스트케이스가 잘 나타나는지 확인
<img width="776" height="602" alt="image" src="https://github.com/user-attachments/assets/60cdcc03-d374-4462-8974-8c82cb415d15" />

- 테스트케이스 정보가 없는 경우 (컴파일 에러 등 실행 전 오류) 테스트케이스를 표시하지 않는지 확인
<img width="766" height="708" alt="image" src="https://github.com/user-attachments/assets/a91b927e-ec76-4e05-8540-97f6fb5ce90a" />

# Ops Impact
N/A

# Version Compatibility
N/A