### PR TITLE
#413 제출 랭킹 API 구현

### DIFF
--- a/backend/submission/tests.py
+++ b/backend/submission/tests.py
@@ -229,8 +229,8 @@ class SubmissionRankAPITest(SubmissionCreateTestBase):
                                             self.problem,
                                             result=JudgeStatus.ACCEPTED,
                                             statistic_info={
-                                                "time_cost": "100",
-                                                "memory_cost": "1024"
+                                                "time_cost": 100,
+                                                "memory_cost": 1024
                                             })
 
         resp = self.client.get(f"{self.url}?submission_id={submission.id}")
@@ -243,18 +243,37 @@ class SubmissionRankAPITest(SubmissionCreateTestBase):
                                             result=JudgeStatus.ACCEPTED,
                                             statistic_info={
                                                 "time_cost": "invalid",
-                                                "memory_cost": "1024"
+                                                "memory_cost": "invalid"
                                             })
 
         resp = self.client.get(f"{self.url}?submission_id={submission.id}")
-        self.assertFailed(resp, "Invalid statistic_info data")
+        self.assertFailed(resp, "Invalid submission statistic_info")
 
         # statistic_info가 비어있는 경우
         submission.statistic_info = {}
         submission.save()
 
         resp = self.client.get(f"{self.url}?submission_id={submission.id}")
-        self.assertFailed(resp, "Submission does not have statistic_info")
+        self.assertFailed(resp, "Invalid submission statistic_info")
+
+    def test_reject_unauthorized_user(self):
+        submission = self.create_submission(user=self.user,
+                                            problem=self.problem,
+                                            result=JudgeStatus.ACCEPTED,
+                                            statistic_info={
+                                                "time_cost": 100,
+                                                "memory_cost": 1024
+                                            })
+
+        # 다른 유저로 요청
+        other_user = self.create_user(
+            email="other",
+            username="other",
+            password="test1234!",
+        )
+
+        resp = self.client.get(f"{self.url}?submission_id={submission.id}", user=other_user)
+        self.assertFailed(resp, "No permission for this submission")
 
     def test_get_submission_rank_multiple_users(self):
         # 여러 유저 생성
@@ -329,8 +348,8 @@ class SubmissionRankAPITest(SubmissionCreateTestBase):
                                             self.problem,
                                             result=JudgeStatus.PENDING,
                                             statistic_info={
-                                                "time_cost": "100",
-                                                "memory_cost": "1024"
+                                                "time_cost": 100,
+                                                "memory_cost": 1024
                                             })
 
         resp = self.client.get(f"{self.url}?submission_id={submission.id}")

--- a/backend/submission/tests.py
+++ b/backend/submission/tests.py
@@ -1,108 +1,339 @@
-from copy import deepcopy
+import copy
+from datetime import timedelta
 from unittest import mock
 
-from problem.models import Problem, ProblemTag
+from django.utils import timezone
+
 from utils.api.tests import APITestCase
-from .models import Submission
+from contest.models import Contest
+from contest.tests import DEFAULT_CONTEST_DATA
+from problem.tests import DEFAULT_PROBLEM_DATA, ProblemCreateTestBase
+from utils.captcha import Captcha
+from utils.throttling import TokenBucket
 
-DEFAULT_PROBLEM_DATA = {
-    "_id": "A-110",
-    "title": "test",
-    "description": "<p>test</p>",
-    "input_description": "test",
-    "output_description": "test",
-    "time_limit": 1000,
-    "memory_limit": 256,
-    "difficulty": "Low",
-    "visible": True,
-    "tags": ["test"],
-    "languages": ["C", "C++", "Java", "Python2"],
-    "template": {},
-    "samples": [{
-        "input": "test",
-        "output": "test"
-    }],
-    "spj": False,
-    "spj_language": "C",
-    "spj_code": "",
-    "test_case_id": "499b26290cc7994e0b497212e842ea85",
-    "test_case_score": [{
-        "output_name": "1.out",
-        "input_name": "1.in",
-        "output_size": 0,
-        "stripped_output_md5": "d41d8cd98f00b204e9800998ecf8427e",
-        "input_size": 0,
-        "score": 0
-    }],
-    "rule_type": "ACM",
-    "hint": "<p>test</p>",
-    "source": "test"
-}
+from .models import Submission, JudgeStatus
 
-DEFAULT_SUBMISSION_DATA = {
-    "problem_id": "1",
-    "user_id": 1,
-    "username": "test",
-    "code": "xxxxxxxxxxxxxx",
-    "result": -2,
-    "info": {},
-    "language": "C",
-    "statistic_info": {}
-}
-
-# todo contest submission
+DEFAULT_SUBMISSION_DATA = {"problem_id": 1, "language": "C++", "code": "#include <iostream>\nint main() { return 0; }"}
 
 
-class SubmissionPrepare(APITestCase):
+class SubmissionCreateTestBase(APITestCase):
 
-    def _create_problem_and_submission(self):
-        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
-        user = self.create_admin(email="test@test.com", username="test", password="test1234!", login=False)
-        problem_data = deepcopy(DEFAULT_PROBLEM_DATA)
-        tags = problem_data.pop("tags")
-        problem_data["created_by"] = user
-        self.problem = Problem.objects.create(**problem_data)
-        for tag in tags:
-            tag = ProblemTag.objects.create(name=tag)
-            self.problem.tags.add(tag)
-        self.problem.save()
-        self.submission_data = deepcopy(DEFAULT_SUBMISSION_DATA)
-        self.submission_data["problem_id"] = self.problem.id
-        self.submission = Submission.objects.create(**self.submission_data)
+    @staticmethod
+    def create_submission(user, problem, **kwargs):
+        data = {
+            "user_id": user.id,
+            "username": user.username,
+            "language": kwargs.get("language", "C++"),
+            "code": kwargs.get("code", "test code"),
+            "problem_id": problem.id,
+            "ip": kwargs.get("ip", "127.0.0.1"),
+            "contest_id": kwargs.get("contest_id", None),
+            "result": kwargs.get("result", JudgeStatus.PENDING),
+            "statistic_info": kwargs.get("statistic_info", {
+                "time_cost": "100",
+                "memory_cost": "1024"
+            }),
+            "shared": kwargs.get("shared", False),
+            "first_failed_tc_idx": kwargs.get("first_failed_tc_idx", None)
+        }
+        return Submission.objects.create(**data)
 
 
-class SubmissionListTest(SubmissionPrepare):
+class SubmissionAPITest(SubmissionCreateTestBase):
 
     def setUp(self):
-        self._create_problem_and_submission()
-        self.create_user(email="testu@test.com", username="testu", password="test1234!")
-        self.url = self.reverse("submission_list_api")
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.url = self.reverse("submission_api")
+        self.admin = self.create_super_admin()
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!")
+        self.problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.admin)
 
-    def test_get_submission_list_with_no_limit(self):
-        resp = self.client.get(self.url, data={})
-        self.assertDictEqual(resp.data, {"error": "error", "data": "Limit is needed"})
+    def test_create_submission_success(self):
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = self.problem.id
 
-    def test_get_submission_list(self):
-        resp = self.client.get(self.url, data={"limit": "10"})
+        with mock.patch('judge.tasks.judge_task.apply_async'):
+            resp = self.client.post(self.url, data=data)
+            self.assertSuccess(resp)
+            self.assertIn("submission_id", resp.data["data"])
+
+    def test_create_submission_nonexistent_problem(self):
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = 99999
+
+        resp = self.client.post(self.url, data=data)
+        self.assertFailed(resp, "Problem not exist")
+
+    def test_create_submission_invalid_language(self):
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = self.problem.id
+        data["language"] = "Python"
+
+        resp = self.client.post(self.url, data=data)
+        self.assertFailed(resp, "language: Python is not a valid language")
+
+    def test_create_submission_invalid_captcha(self):
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = self.problem.id
+        data["captcha"] = "invalid"
+
+        with mock.patch.object(Captcha, 'check', return_value=False):
+            resp = self.client.post(self.url, data=data)
+            self.assertFailed(resp, "Invalid captcha")
+
+    def test_create_submission_throttling(self):
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = self.problem.id
+
+        with mock.patch.object(TokenBucket, 'consume', return_value=(False, 30)):
+            resp = self.client.post(self.url, data=data)
+            self.assertFailed(resp, "Please wait 30 seconds")
+
+    def test_get_submission_success(self):
+        submission = self.create_submission(self.user, self.problem)
+
+        resp = self.client.get(f"{self.url}?id={submission.id}")
+        self.assertSuccess(resp)
+        self.assertEqual(resp.data["data"]["id"], submission.id)
+
+    def test_get_submission_nonexistent(self):
+        resp = self.client.get(f"{self.url}?id=99999")
+        self.assertFailed(resp, "Submission doesn't exist")
+
+    def test_get_submission_no_permission(self):
+        other_user = self.create_user(email="other@test.com", username="other", password="test1234!", login=False)
+        submission = self.create_submission(other_user, self.problem)
+
+        resp = self.client.get(f"{self.url}?id={submission.id}")
+        self.assertFailed(resp, "No permission for this submission")
+
+    def test_get_submission_with_testcase_info(self):
+        submission = self.create_submission(self.user, self.problem, first_failed_tc_idx=1)
+
+        with mock.patch('utils.testcase_cache.TestCaseCacheManager.get_testcase', return_value={"input": "1 2"}):
+            resp = self.client.get(f"{self.url}?id={submission.id}")
+            self.assertSuccess(resp)
+            self.assertIn("first_failed_tc_io", resp.data["data"])
+
+    def test_share_submission_success(self):
+        submission = self.create_submission(self.user, self.problem)
+
+        data = {"id": submission.id, "shared": True}
+        resp = self.client.put(self.url, data=data)
         self.assertSuccess(resp)
 
+    def test_share_submission_no_permission(self):
+        other_user = self.create_user(email="other@test.com", username="other", password="test1234!", login=False)
+        submission = self.create_submission(other_user, self.problem)
 
-@mock.patch("submission.views.oj.judge_task.send")
-class SubmissionAPITest(SubmissionPrepare):
+        data = {"id": submission.id, "shared": True}
+        resp = self.client.put(self.url, data=data)
+        self.assertFailed(resp, "No permission to share the submission")
+
+
+class ContestSubmissionAPITest(SubmissionCreateTestBase):
 
     def setUp(self):
-        self._create_problem_and_submission()
-        self.user = self.create_user(email="testuser@test.com", username="testuser", password="test1234!")
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!")
+        self.create_super_admin()
+
+        contest_data = copy.deepcopy(DEFAULT_CONTEST_DATA)
+        contest_data["start_time"] = timezone.now() - timedelta(hours=1)
+        contest_data["end_time"] = timezone.now() + timedelta(hours=1)
+        contest_resp = self.client.post(self.reverse("contest_admin_api"), data=contest_data)
+        self.assertSuccess(contest_resp)
+        self.contest = contest_resp.data["data"]
+
+        self.contest_problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.user)
+        self.contest_problem.contest_id = self.contest["id"]
+        self.contest_problem.save()
+
         self.url = self.reverse("submission_api")
 
-    def test_create_submission(self, judge_task):
-        resp = self.client.post(self.url, self.submission_data)
-        self.assertSuccess(resp)
-        judge_task.assert_called()
+    def test_create_contest_submission_ended(self):
+        contest = Contest.objects.get(id=self.contest["id"])
+        contest.end_time = timezone.now() - timedelta(hours=1)
+        contest.save()
 
-    def test_create_submission_with_wrong_language(self, judge_task):
-        self.submission_data.update({"language": "Python3"})
-        resp = self.client.post(self.url, self.submission_data)
-        self.assertFailed(resp)
-        self.assertDictEqual(resp.data, {"error": "error", "data": "Python3 is now allowed in the problem"})
-        judge_task.assert_not_called()
+        data = copy.deepcopy(DEFAULT_SUBMISSION_DATA)
+        data["problem_id"] = self.contest_problem.id
+        data["contest_id"] = self.contest["id"]
+
+        resp = self.client.post(self.reverse("submission_api"), data=data)
+        self.assertFailed(resp, "The contest have ended")
+
+    def test_get_contest_submission_list(self):
+        submission = self.create_submission(self.user, self.contest_problem, contest_id=self.contest["id"])
+
+        resp = self.client.get(f"{self.reverse('submission_list_api')}?limit=10")
+        self.assertSuccess(resp)
+
+
+class SubmissionListAPITest(SubmissionCreateTestBase):
+
+    def setUp(self):
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.admin = self.create_admin(login=False)
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!")
+        self.problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.admin)
+        self.url = self.reverse("submission_list_api")
+
+    def test_get_submission_list_success(self):
+        submission = self.create_submission(self.user, self.problem)
+
+        resp = self.client.get(f"{self.url}?limit=10")
+        self.assertSuccess(resp)
+
+    def test_get_submission_list_no_limit(self):
+        resp = self.client.get(self.url)
+        self.assertFailed(resp, "Limit is needed")
+
+    def test_get_submission_list_contest_id_error(self):
+        resp = self.client.get(f"{self.url}?limit=10&contest_id=1")
+        self.assertFailed(resp, "Parameter error")
+
+
+class SubmissionExistsAPITest(SubmissionCreateTestBase):
+
+    def setUp(self):
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.admin = self.create_admin(login=False)
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!")
+        self.problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.admin)
+        self.url = self.reverse("submission_exists")
+
+    def test_submission_exists_true(self):
+        submission = self.create_submission(self.user, self.problem)
+
+        resp = self.client.get(f"{self.url}?problem_id={self.problem.id}")
+        self.assertSuccess(resp)
+        self.assertTrue(resp.data["data"])
+
+    def test_submission_exists_no_problem_id(self):
+        resp = self.client.get(self.url)
+        self.assertFailed(resp, "Parameter error, problem_id is required")
+
+
+class SubmissionRankAPITest(SubmissionCreateTestBase):
+
+    def setUp(self):
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.admin = self.create_admin(login=False)
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!")
+        self.problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.admin)
+        self.url = self.reverse("submission_rank_api")
+
+    def test_get_submission_rank_success(self):
+        submission = self.create_submission(self.user,
+                                            self.problem,
+                                            result=JudgeStatus.ACCEPTED,
+                                            statistic_info={
+                                                "time_cost": "100",
+                                                "memory_cost": "1024"
+                                            })
+
+        resp = self.client.get(f"{self.url}?submission_id={submission.id}")
+        self.assertSuccess(resp)
+        self.assertIn("solved_rank", resp.data["data"])
+
+    def test_statistic_info_invalid(self):
+        submission = self.create_submission(self.user,
+                                            self.problem,
+                                            result=JudgeStatus.ACCEPTED,
+                                            statistic_info={
+                                                "time_cost": "invalid",
+                                                "memory_cost": "1024"
+                                            })
+
+        resp = self.client.get(f"{self.url}?submission_id={submission.id}")
+        self.assertFailed(resp, "Invalid statistic_info data")
+
+        # statistic_info가 비어있는 경우
+        submission.statistic_info = {}
+        submission.save()
+
+        resp = self.client.get(f"{self.url}?submission_id={submission.id}")
+        self.assertFailed(resp, "Submission does not have statistic_info")
+
+    def test_get_submission_rank_multiple_users(self):
+        # 여러 유저 생성
+        user1 = self.create_user(email="user1@test.com", username="user1", password="test1234!")
+        user2 = self.create_user(email="user2@test.com", username="user2", password="test1234!")
+        user3 = self.create_user(email="user3@test.com", username="user3", password="test1234!")
+
+        problem = self.problem
+
+        # user1: Accepted, time_cost 100, memory_cost 1024, 제출 시각 가장 빠름
+        sub1 = self.create_submission(user1,
+                                      problem,
+                                      result=JudgeStatus.ACCEPTED,
+                                      statistic_info={
+                                          "time_cost": 100,
+                                          "memory_cost": 1024
+                                      })
+        # 인위적으로 생성 시간 조절 (예: sub1가 가장 먼저 제출)
+        Submission.objects.filter(id=sub1.id).update(create_time=timezone.now() - timedelta(minutes=10))
+
+        # user2: Accepted, time_cost 200, memory_cost 2048
+        sub2 = self.create_submission(user2,
+                                      problem,
+                                      result=JudgeStatus.ACCEPTED,
+                                      statistic_info={
+                                          "time_cost": 200,
+                                          "memory_cost": 2048
+                                      })
+        Submission.objects.filter(id=sub2.id).update(create_time=timezone.now() - timedelta(minutes=5))
+
+        # user3: Accepted, time_cost 150, memory_cost 1024
+        sub3 = self.create_submission(user3,
+                                      problem,
+                                      result=JudgeStatus.ACCEPTED,
+                                      statistic_info={
+                                          "time_cost": 150,
+                                          "memory_cost": 1024
+                                      })
+        Submission.objects.filter(id=sub3.id).update(create_time=timezone.now() - timedelta(minutes=1))
+
+        # user3의 제출물로 랭크 조회
+        resp = self.client.get(f"{self.url}?submission_id={sub3.id}")
+        self.assertSuccess(resp)
+
+        data = resp.data["data"]
+
+        # solved_rank: sub1가 10분 전에 제출한 Accepted, sub2는 5분 전, sub3는 1분 전 -> solved_rank = 2 (2명 앞섬)
+        self.assertEqual(data["solved_rank"], 3)
+
+        # time_cost ranking:
+        # sub1(100), sub3(150), sub2(200) 순
+        # sub3의 time_cost는 150, 'time_cost < 150'인것은 sub1(100) 1개 -> rank = 2
+        # total_count = 3
+        self.assertEqual(data["time_cost_percent"], round(2 / 3 * 100, 2))
+
+        # memory_cost ranking:
+        # sub1(1024), sub3(1024), sub2(2048)
+        # 'memory_cost < 1024'는 없음 -> rank = 1
+        self.assertEqual(data["memory_cost_percent"], round(1 / 3 * 100, 2))
+
+    def test_get_submission_rank_no_submission_id(self):
+        resp = self.client.get(self.url)
+        self.assertFailed(resp, "Parameter submission_id is required")
+
+    def test_get_submission_rank_nonexistent(self):
+        resp = self.client.get(f"{self.url}?submission_id=99999")
+        self.assertFailed(resp, "Submission does not exist")
+
+    def test_get_submission_rank_total_zero(self):
+        # Accepted된 submission이 없는 상태: 새로 제출 생성 (Accepted 외 상태로)
+        submission = self.create_submission(self.user,
+                                            self.problem,
+                                            result=JudgeStatus.PENDING,
+                                            statistic_info={
+                                                "time_cost": "100",
+                                                "memory_cost": "1024"
+                                            })
+
+        resp = self.client.get(f"{self.url}?submission_id={submission.id}")
+        self.assertSuccess(resp)
+        self.assertEqual(resp.data["data"]["time_cost_percent"], 0.0)
+        self.assertEqual(resp.data["data"]["memory_cost_percent"], 0.0)

--- a/backend/submission/tests.py
+++ b/backend/submission/tests.py
@@ -308,12 +308,12 @@ class SubmissionRankAPITest(SubmissionCreateTestBase):
         # sub1(100), sub3(150), sub2(200) 순
         # sub3의 time_cost는 150, 'time_cost < 150'인것은 sub1(100) 1개 -> rank = 2
         # total_count = 3
-        self.assertEqual(data["time_cost_percent"], round(2 / 3 * 100, 2))
+        self.assertEqual(data["time_cost_percent"], round(1 / 3 * 100, 2))
 
         # memory_cost ranking:
         # sub1(1024), sub3(1024), sub2(2048)
         # 'memory_cost < 1024'는 없음 -> rank = 1
-        self.assertEqual(data["memory_cost_percent"], round(1 / 3 * 100, 2))
+        self.assertEqual(data["memory_cost_percent"], round(0 / 3 * 100, 2))
 
     def test_get_submission_rank_no_submission_id(self):
         resp = self.client.get(self.url)

--- a/backend/submission/urls/oj.py
+++ b/backend/submission/urls/oj.py
@@ -1,9 +1,10 @@
 from django.conf.urls import url
 
-from ..views.oj import SubmissionAPI, SubmissionListAPI, SubmissionExistsAPI
+from ..views.oj import SubmissionAPI, SubmissionListAPI, SubmissionExistsAPI, SubmissionRankAPI
 
 urlpatterns = [
     url(r"^submission/?$", SubmissionAPI.as_view(), name="submission_api"),
     url(r"^submissions/?$", SubmissionListAPI.as_view(), name="submission_list_api"),
     url(r"^submission_exists/?$", SubmissionExistsAPI.as_view(), name="submission_exists"),
+    url(r"^submission_rank/?$", SubmissionRankAPI.as_view(), name="submission_rank_api"),
 ]

--- a/backend/submission/views/oj.py
+++ b/backend/submission/views/oj.py
@@ -1,16 +1,12 @@
 import ipaddress
 
-from django.db.models import Q, Count, IntegerField
-from django.db.models.fields.json import KeyTextTransform
-from django.db.models.functions import Cast
+from django.db.models import Q, Count
 
 from account.decorators import login_required, check_contest_permission
 from utils.testcase_cache import TestCaseCacheManager
 from contest.models import ContestStatus, ContestRuleType
-from judge.dispatcher import JudgeDispatcher
 from judge.tasks import judge_task
 from options.options import SysOptions
-# from judge.dispatcher import JudgeDispatcher
 from problem.models import Problem, ProblemRuleType
 from utils.api import APIView, validate_serializer
 from utils.cache import cache

--- a/backend/submission/views/oj.py
+++ b/backend/submission/views/oj.py
@@ -291,12 +291,11 @@ class SubmissionRankAPI(APIView):
         solved_rank = rank_data['earlier_solved_users'] + 1
 
         time_total = rank_data['total_time_submissions']
-        time_cost_percent = round(
-            (rank_data['faster_submissions'] + 1) / time_total * 100, 2) if time_total > 0 else 0.0
+        time_cost_percent = round(rank_data['faster_submissions'] / time_total * 100, 2) if time_total > 0 else 0.0
 
         memory_total = rank_data['total_memory_submissions']
-        memory_cost_percent = round(
-            (rank_data['less_memory_submissions'] + 1) / memory_total * 100, 2) if memory_total > 0 else 0.0
+        memory_cost_percent = round(rank_data['less_memory_submissions'] / memory_total *
+                                    100, 2) if memory_total > 0 else 0.0
 
         return self.success({
             'solved_rank': solved_rank,

--- a/backend/submission/views/oj.py
+++ b/backend/submission/views/oj.py
@@ -223,7 +223,15 @@ class SubmissionRankAPI(APIView):
 
     @login_required
     def get(self, request):
-        """제출물의 순위 정보를 반환합니다 (해결 순위, 실행시간 순위, 메모리 순위)"""
+        """제출물의 순위 정보를 반환합니다.
+
+        순위 정보는 다음과 같습니다:
+            - solved_rank: 제출자가 문제를 푼 순위 (해당 제출 이전에 문제를 푼 사용자 수 + 1)
+            - time_cost_percent: 제출자의 시간 비용이 전체 제출 중 몇 퍼센트인지
+            - memory_cost_percent: 제출자의 메모리 비용이 전체 제출 중 몇 퍼센트인지
+
+        이 API는 제출물의 ID를 통해 해당 제출물의 통계 정보를 기반으로 순위를 계산합니다.
+        """
 
         # submission_id 파라미터가 없으면 에러 반환
         submission_id = request.GET.get("submission_id")


### PR DESCRIPTION
# Changelog
- 특정 제출이 해당 문제의 모든 제출 중의 순위를 반환하는 API `SubmissionRankAPI`를 구현하였습니다.
  - 해당 문제를 해결한 순위
  - 시간 비용 순위 (언어별로 분리)
  - 메모리 비용 순위 (언어별로 분리)
- `Submisison`에 실패하던 테스트들을 수정하여 통과하도록 수정하였습니다.

# Testing
- 유닛테스트 결과
<img width="808" height="180" alt="image" src="https://github.com/user-attachments/assets/99b6ebd9-9c79-4e75-961f-14f62b23f596" />

- API 테스트
<img width="704" height="669" alt="image" src="https://github.com/user-attachments/assets/fe53b869-85ba-4345-b349-bd4f22ae8121" />

# Ops Impact
N/A

# Version Compatibility
N/A