### PR TITLE
#413 CodeHighlight 컴포넌트 스타일 개선

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
@@ -108,6 +108,8 @@ export default {
   --error-bg: #2d1b1b;
   --error-text: #f87171;
   --error-border: #7f1d1d;
+  --box-shadow: 0 2px 8px rgba(255, 255, 255, 0.06);
+  --box-shadow-hover: 0 4px 12px rgba(255, 255, 255, 0.1);
 }
 
 .light-theme {
@@ -117,6 +119,8 @@ export default {
   --error-bg: #fef2f2;
   --error-text: #dc2626;
   --error-border: #fecaca;
+  --box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  --box-shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 .error-info {
@@ -136,12 +140,12 @@ export default {
   background-color: var(--dropdown-bg);
   color: var(--dropdown-text);
   border: 1px solid var(--border-color);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--box-shadow);
   transition: all 0.2s ease;
 }
 
 .code-highlight-wrapper:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--box-shadow-hover);
 }
 
 code {


### PR DESCRIPTION
# Changelog
- 기존에 Box Shadow가 라이트모드 기준으로 고정돼있어서 Dark/Light에 따라 Box Shadow를 동적으로 변경하도록 변경하였습니다.

# Testing
- 라이트모드에서 호버 시 Shadow 확인
<img width="804" height="347" alt="image" src="https://github.com/user-attachments/assets/28cde024-115f-40cf-a0c3-d87df5029159" />

- 다크모드에서 호버 시 Shadow 확인
<img width="811" height="348" alt="image" src="https://github.com/user-attachments/assets/4e48632c-cdeb-4384-933b-bb7bcec8ac0b" />

# Ops Impact
N/A

# Version Compatibility
N/A