### PR TITLE
#413 제출 현황 탭 UX 개선

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -292,7 +292,6 @@ export default {
 
               this.leftPainActiveTab = "submission";
               this.lastSubmissionId = id;
-              console.log("lastSubmissionId:", this.lastSubmissionId);
 
               clearTimeout(this.refreshStatus);
               this.init();

--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -21,14 +21,15 @@
           </div>
           <div class="tab-content">
             <ProblemDetailFlexibleContainer
-              v-if="leftPainActiveTab === 'problem'"
+              v-show="leftPainActiveTab === 'problem'"
               :problem="problem"
               :contestID="contestID"
             />
             <SubmissionList
-              v-if="leftPainActiveTab === 'submission'"
+              v-show="leftPainActiveTab === 'submission'"
               :problemID="problemID"
               :contestID="contestID"
+              :lastSubmissionId="lastSubmissionId"
               :isDarkMode="isDarkMode"
             />
           </div>
@@ -161,6 +162,7 @@ export default {
       modalCheck: false,
       leftPainActiveTab: "problem",
       rightPainActiveTab: "editor",
+      lastSubmissionId: null,
     };
   },
   beforeRouteEnter(to, from, next) {
@@ -287,6 +289,11 @@ export default {
             if (Object.keys(res.data.data.statistic_info).length !== 0) {
               this.submitting = false;
               this.submitted = false;
+
+              this.leftPainActiveTab = "submission";
+              this.lastSubmissionId = id;
+              console.log("lastSubmissionId:", this.lastSubmissionId);
+
               clearTimeout(this.refreshStatus);
               this.init();
             } else {

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionList.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionList.vue
@@ -4,12 +4,13 @@
       <table class="submission-table">
         <thead>
           <tr>
-            <th></th>
+            <th>No.</th>
             <th>결과</th>
             <th>언어</th>
             <th>실행 시간</th>
             <th>메모리</th>
-            <th>제출 일자</th>
+            <th>제출 일자 {{ this.lastSubmissionId || "no" }}</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -18,7 +19,10 @@
             <tr
               :key="submission.id"
               @click="selectSubmission(submission)"
-              :class="{ selected: selectedSubmissionId === submission.id }"
+              class="submission-row"
+              :class="{
+                selected: internalSelectedSubmissionId === submission.id,
+              }"
             >
               <td>{{ submissions.length - idx }}</td>
               <td class="status-cell">
@@ -49,15 +53,22 @@
                 {{ formatMemoryCost(submission.statistic_info.memory_cost) }}
               </td>
               <td>{{ formatTime(submission.create_time) }}</td>
+              <td>
+                <Icon
+                  v-if="internalSelectedSubmissionId !== submission.id"
+                  type="ios-arrow-down"
+                />
+                <Icon v-else type="ios-arrow-up" class="rotate-icon" />
+              </td>
             </tr>
 
             <!-- 드롭다운 행 -->
             <tr
-              v-if="selectedSubmissionId === submission.id"
+              v-if="internalSelectedSubmissionId === submission.id"
               :key="`dropdown-${submission.id}`"
               class="dropdown-row"
             >
-              <td colspan="6" class="dropdown-cell">
+              <td colspan="7" class="dropdown-cell">
                 <div class="dropdown-content">
                   <SubmissionErrorDropdown
                     v-if="submission.result !== 0"
@@ -111,11 +122,15 @@ export default {
       type: Boolean,
       default: false,
     },
+    lastSubmissionId: {
+      type: String,
+      default: null,
+    },
   },
   data() {
     return {
       submissions: [],
-      selectedSubmissionId: null,
+      internalSelectedSubmissionId: null,
       judgeStatus: JUDGE_STATUS,
     };
   },
@@ -127,9 +142,31 @@ export default {
   mounted() {
     this.getSubmissionList();
   },
+  watch: {
+    async lastSubmissionId(newId, oldId) {
+      // 값이 실제로 변경되었을 때만 실행
+      if (newId !== oldId && newId) {
+        try {
+          console.log("Last submission ID changed:", newId);
+          // 1. 제출 목록 새로고침
+          await this.getSubmissionList();
+
+          // 2. DOM 업데이트 완료 대기
+          await this.$nextTick();
+
+          // 3. 해당 제출을 선택
+          this.selectSubmissionById(newId);
+        } catch (error) {
+          console.error("Failed to process lastSubmissionId change:", error);
+          this.internalSelectedSubmissionId = null;
+        }
+      }
+    },
+  },
   methods: {
     async getSubmissionList() {
       try {
+        console.log("Fetching submission list for problem ID:", this.problemID);
         const params = {
           myself: "1",
           problem_id: this.problemID,
@@ -141,14 +178,29 @@ export default {
       }
     },
 
+    selectSubmissionById(submissionId) {
+      console.log("Selecting submission by ID:", submissionId);
+      const submission = this.submissions.find(
+        (sub) => sub.id === submissionId
+      );
+      if (submission) {
+        console.log("Selecting submission:", submission);
+        this.selectSubmission(submission);
+      } else {
+        console.warn("Submission not found for ID:", submissionId);
+        this.internalSelectedSubmissionId = null;
+      }
+    },
+
     async selectSubmission(submission) {
-      if (this.selectedSubmissionId === submission.id) {
-        this.selectedSubmissionId = null;
+      if (this.internalSelectedSubmissionId === submission.id) {
+        this.internalSelectedSubmissionId = null;
         return;
       }
 
-      this.selectedSubmissionId = submission.id;
+      this.internalSelectedSubmissionId = submission.id;
 
+      // 코드가 없는 경우에만 상세 정보 fetch
       if (!submission.code) {
         await this.fetchSubmissionDetails(submission);
       }
@@ -244,7 +296,7 @@ export default {
   td {
     text-align: start;
     vertical-align: middle;
-    padding: 12px 0;
+    padding: 12px 14px;
     font-size: 14px;
 
     &:first-child {
@@ -262,6 +314,7 @@ export default {
 
   tbody tr {
     transition: background 0.2s;
+    padding: 0 12px;
     cursor: pointer;
 
     &.selected {
@@ -272,6 +325,10 @@ export default {
     &.dropdown-row {
       cursor: default !important;
     }
+  }
+
+  .submission-row:hover {
+    background: var(--row-hover-bg);
   }
 }
 
@@ -307,13 +364,13 @@ export default {
 }
 
 .dropdown-content {
-  animation: slideDown 0.3s ease-out;
+  animation: slideDown 0.8s ease-out;
 }
 
 @keyframes slideDown {
   from {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: translateY(-15px);
   }
   to {
     opacity: 1;

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionList.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionList.vue
@@ -9,7 +9,7 @@
             <th>언어</th>
             <th>실행 시간</th>
             <th>메모리</th>
-            <th>제출 일자 {{ this.lastSubmissionId || "no" }}</th>
+            <th>제출 일자</th>
             <th></th>
           </tr>
         </thead>
@@ -147,7 +147,6 @@ export default {
       // 값이 실제로 변경되었을 때만 실행
       if (newId !== oldId && newId) {
         try {
-          console.log("Last submission ID changed:", newId);
           // 1. 제출 목록 새로고침
           await this.getSubmissionList();
 
@@ -166,7 +165,6 @@ export default {
   methods: {
     async getSubmissionList() {
       try {
-        console.log("Fetching submission list for problem ID:", this.problemID);
         const params = {
           myself: "1",
           problem_id: this.problemID,
@@ -179,12 +177,10 @@ export default {
     },
 
     selectSubmissionById(submissionId) {
-      console.log("Selecting submission by ID:", submissionId);
       const submission = this.submissions.find(
         (sub) => sub.id === submissionId
       );
       if (submission) {
-        console.log("Selecting submission:", submission);
         this.selectSubmission(submission);
       } else {
         console.warn("Submission not found for ID:", submissionId);

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionStatus.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionStatus.vue
@@ -3,51 +3,75 @@
     <template v-if="!statusVisible">
       <span>제출결과</span>
     </template>
-    <template v-else-if="statusVisible && (!this.contestID || (this.contestID && OIContestRealTimePermission))">
-      <div class="submissionState" @click="handleRoute('/status/'+submissionId)">
-        <i v-if="(submissionStatus.text === 'Submitting') || (submissionStatus.text === 'Judging')"
-           class="fas fa-circle-notch fa-spin" style="color: #e39530"/>
-        <i v-else class="fas fa-circle" :style="{'color': submissionStatus.color}"/>
-        {{ $t('m.' + submissionStatus.text.replace(/ /g, "_")) }}
+    <template
+      v-else-if="
+        statusVisible &&
+        (!this.contestID || (this.contestID && OIContestRealTimePermission))
+      "
+    >
+      <div
+        class="submissionState"
+        @click="handleRoute('/status/' + submissionId)"
+      >
+        <i
+          v-if="
+            submissionStatus.text === 'Submitting' ||
+            submissionStatus.text === 'Judging'
+          "
+          class="fas fa-circle-notch fa-spin"
+          style="color: #e39530"
+        />
+        <i
+          v-else
+          class="fas fa-circle"
+          :style="{ color: submissionStatus.color }"
+        />
+        {{ $t("m." + submissionStatus.text.replace(/ /g, "_")) }}
       </div>
     </template>
-    <template v-else-if="statusVisible && (this.contestID && !OIContestRealTimePermission)">
-      <Alert type="success" show-icon>{{ $t('m.Submitted_successfully') }}</Alert>
+    <template
+      v-else-if="
+        statusVisible && this.contestID && !OIContestRealTimePermission
+      "
+    >
+      <Alert type="success" show-icon>{{
+        $t("m.Submitted_successfully")
+      }}</Alert>
     </template>
   </div>
 </template>
 
 <script>
-import {defineComponent} from "vue";
-import {mapGetters} from "vuex";
-import {JUDGE_STATUS} from "../../../../../../utils/constants";
+import { defineComponent } from "vue";
+import { mapGetters } from "vuex";
+import { JUDGE_STATUS } from "../../../../../../utils/constants";
 
 export default defineComponent({
   props: {
     statusVisible: Boolean,
     contestID: String,
     result: Object,
-    submissionId: String
+    submissionId: String,
   },
   components: {},
   data() {
-    return {}
+    return {};
   },
   methods: {
     handleRoute(route) {
-      this.$router.push(route)
-    }
+      this.$router.push(route);
+    },
   },
   computed: {
-    ...mapGetters(['OIContestRealTimePermission']),
+    ...mapGetters(["OIContestRealTimePermission"]),
     submissionStatus() {
       return {
-        text: JUDGE_STATUS[this.result.result]['name'],
-        color: JUDGE_STATUS[this.result.result]['color']
-      }
+        text: JUDGE_STATUS[this.result.result]["name"],
+        color: JUDGE_STATUS[this.result.result]["color"],
+      };
     },
-  }
-})
+  },
+});
 </script>
 
 <style scoped lang="less">


### PR DESCRIPTION
# Changelog
- 문제 제출 후 결과가 나온 경우, 제출 현황 > 해당 제출 상세보기 드롭다운으로 이동시킵니다.
  1. Problem 컴포넌트는 SubmissionList 컴포넌트에 `lastSubmisisonId`를 전달합니다.
  2. 채점이 완료되면, lastSubmissionId를 해당 제출로 변경하고, SubmissionList 컴포넌트에 전달합니다.
  3. SubmissionList 컴포넌트는 lastSubmissionId를 watch로 감시하고 있다가, 변경된 경우 제출 목록을 업데이트하고 해당 제출을 selectedSubmisison으로 설정합니다.
- 제출 현황에서 제출들이 드롭다운을 가지고 있는 것을 사용자들이 쉽게 알 수 있도록 각 행의 오른쪽에 화살표를 추가하였습니다.
- 제출 현황의 각 행들의 Padding을 늘렸습니다.

# Testing
https://github.com/user-attachments/assets/d56979b8-ebe9-44d5-b397-c23e48b4008e

# Ops Impact
N/A

# Version Compatibility
N/A