### PR TITLE
#413 제출 현황 컴포넌트 분리 및 리팩토링

### DIFF
--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -327,7 +327,7 @@ export default {
   },
   getSubmissionRank(id) {
     const params = { submission_id: id };
-    return ajax('submission_rank', "get", {
+    return ajax("submission_rank", "get", {
       params: params,
     });
   },

--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -26,6 +26,7 @@
               :contestID="contestID"
             />
             <SubmissionList
+              v-if="isInitialized"
               v-show="leftPainActiveTab === 'submission'"
               :problemID="problemID"
               :contestID="contestID"
@@ -163,6 +164,7 @@ export default {
       leftPainActiveTab: "problem",
       rightPainActiveTab: "editor",
       lastSubmissionId: null,
+      isInitialized: false,
     };
   },
   beforeRouteEnter(to, from, next) {
@@ -190,6 +192,7 @@ export default {
     this.$store.commit(types.CHANGE_CONTEST_ITEM_VISIBLE, { menu: false });
     this.init();
     window.addEventListener("beforeunload", this.unLoadEvent);
+    this.isInitialized = true;
   },
   beforeUnmount() {
     window.removeEventListener("beforeunload", this.unLoadEvent);

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeHighlight.vue
@@ -142,6 +142,20 @@ export default {
   border: 1px solid var(--border-color);
   box-shadow: var(--box-shadow);
   transition: all 0.2s ease;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background: var(--dropdown-bg);
+    border-radius: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--border-color);
+    border-radius: 4px;
+    border: 2px solid var(--dropdown-bg);
+  }
 }
 
 .code-highlight-wrapper:hover {

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ExpandableCode.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ExpandableCode.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="expandable-code">
+    <div class="code-header">
+      <p class="sub-title">{{ title }}</p>
+      <span class="expand-hint" v-if="!isExpanded">클릭하여 펼치기</span>
+    </div>
+    <div
+      class="code-wrapper"
+      :class="{ expanded: isExpanded }"
+      @click="toggleExpansion"
+    >
+      <CodeHighlight
+        :type="codeType"
+        :code="code"
+        :language="language"
+        :isDarkMode="isDarkMode"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import CodeHighlight from "./CodeHighlight.vue";
+
+export default {
+  name: "ExpandableCode",
+  components: {
+    CodeHighlight,
+  },
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    code: {
+      type: String,
+      default: "",
+    },
+    language: {
+      type: String,
+      default: "plaintext",
+    },
+    codeType: {
+      type: String,
+      default: "code",
+    },
+    isDarkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      isExpanded: false,
+    };
+  },
+  methods: {
+    toggleExpansion() {
+      this.isExpanded = !this.isExpanded;
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+.expandable-code {
+  .code-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .sub-title {
+      font-size: 14px;
+      font-weight: bold;
+      margin-bottom: 12px;
+    }
+
+    .expand-hint {
+      font-size: 12px;
+      color: var(--text-color);
+      font-style: italic;
+    }
+  }
+
+  .code-wrapper {
+    cursor: pointer;
+    transition: all 0.3s ease;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.02);
+    }
+
+    /deep/ .code-highlight-wrapper {
+      max-height: 300px;
+      overflow: hidden;
+      transition: max-height 0.3s ease;
+    }
+
+    &.expanded {
+      /deep/ .code-highlight-wrapper {
+        max-height: none;
+      }
+    }
+  }
+}
+</style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
@@ -299,6 +299,20 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
 
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background: var(--dropdown-bg);
+    border-radius: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--border-color);
+    border-radius: 4px;
+    border: 2px solid var(--dropdown-bg);
+  }
+
   .detailCard {
     border: none;
     flex: 1;

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionDropdown.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionDropdown.vue
@@ -1,0 +1,78 @@
+<template>
+  <tr class="dropdown-row">
+    <td colspan="7" class="dropdown-cell">
+      <div class="dropdown-content">
+        <SubmissionAcceptedDropdown
+          v-if="isAccepted"
+          :submission="submission"
+          :contestID="contestID"
+          :isDarkMode="isDarkMode"
+        />
+        <SubmissionErrorDropdown
+          v-else
+          :submission="submission"
+          :contestID="contestID"
+          :isDarkMode="isDarkMode"
+        />
+      </div>
+    </td>
+  </tr>
+</template>
+
+<script>
+import SubmissionAcceptedDropdown from "./SubmissionAcceptedDropdown.vue";
+import SubmissionErrorDropdown from "./SubmissionErrorDropdown.vue";
+
+export default {
+  name: "SubmissionDropdown",
+  components: {
+    SubmissionAcceptedDropdown,
+    SubmissionErrorDropdown,
+  },
+  props: {
+    submission: {
+      type: Object,
+      required: true,
+    },
+    contestID: {
+      type: String,
+      default: null,
+    },
+    isDarkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    isAccepted() {
+      return this.submission.result === 0;
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+.dropdown-row {
+  cursor: default;
+}
+
+.dropdown-cell {
+  padding: 10px;
+  border-bottom: 1px solid var(--dropdown-border);
+}
+
+.dropdown-content {
+  animation: slideDown 0.8s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-15px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionErrorDropdown.vue
@@ -10,87 +10,55 @@
       />
     </div>
 
-    <!-- 테스트케이스 정보 섹션 -->
-    <div v-if="hasFailedTestCase">
-      <div class="failed-tc-header">
-        <p>최초 실패 케이스</p>
-        <CustomTooltip
-          content="테스트케이스 중 최초로 실패한 케이스의 입력값과 기대값입니다."
-          placement="right"
-        >
-          <Icon type="ios-information" />
-        </CustomTooltip>
-      </div>
-      <div class="testcase-info">
-        <div class="testcase-input">
-          <p>입력값</p>
-          <CodeHighlight
-            type="plaintext"
-            :code="submission.first_failed_tc_io.input || ''"
-            :isDarkMode="isDarkMode"
-          />
-        </div>
-        <div class="testcase-output">
-          <p>기대값</p>
-          <CodeHighlight
-            type="plaintext"
-            :code="submission.first_failed_tc_io.output || ''"
-            :isDarkMode="isDarkMode"
-          />
-        </div>
-      </div>
-    </div>
+    <!-- 테스트케이스 정보 섹션 (contestID가 없을 때만 표시) -->
+    <TestCaseInfo
+      v-if="shouldShowTestCase"
+      :testCase="submission.first_failed_tc_io"
+      :isDarkMode="isDarkMode"
+    />
 
     <!-- 제출 코드 섹션 -->
-    <div class="submission-code-section">
-      <div class="code-header">
-        <p class="sub-title">제출 코드</p>
-        <span class="expand-hint" v-if="!isCodeExpanded">클릭하여 펼치기</span>
-      </div>
-      <div
-        class="code-wrapper"
-        :class="{ expanded: isCodeExpanded }"
-        @click="toggleCodeExpansion"
-      >
-        <CodeHighlight
-          type="code"
-          :code="submission.code || ''"
-          :language="getHljsLanguage(submission.language)"
-          :isDarkMode="isDarkMode"
-        />
-      </div>
-    </div>
+    <ExpandableCode
+      title="제출 코드"
+      :code="submission.code || ''"
+      :language="getHljsLanguage(submission.language)"
+      :isDarkMode="isDarkMode"
+    />
   </div>
 </template>
 
 <script>
 import CodeHighlight from "./CodeHighlight.vue";
-import CustomTooltip from "@oj/components/CustomTooltip";
+import TestCaseInfo from "./TestCaseInfo.vue";
+import ExpandableCode from "./ExpandableCode.vue";
 import { HIGHLIGHT_JS_LANGUAGES } from "../../../../../../utils/constants";
 
 export default {
   name: "SubmissionErrorDropdown",
   components: {
     CodeHighlight,
-    CustomTooltip,
+    TestCaseInfo,
+    ExpandableCode,
   },
   props: {
     submission: {
       type: Object,
       required: true,
     },
+    contestID: {
+      type: String,
+      default: null,
+    },
     isDarkMode: {
       type: Boolean,
       default: false,
     },
   },
-  data() {
-    return {
-      isCodeExpanded: false,
-    };
-  },
   computed: {
-    hasFailedTestCase() {
+    shouldShowTestCase() {
+      // contestID가 없고, 실패한 테스트케이스 정보가 있을 때만 표시
+      if (this.contestID) return false;
+
       const tcInfo = this.submission.first_failed_tc_io;
       return tcInfo && tcInfo.input && tcInfo.output;
     },
@@ -98,9 +66,6 @@ export default {
   methods: {
     getHljsLanguage(language) {
       return HIGHLIGHT_JS_LANGUAGES[language] || "plaintext";
-    },
-    toggleCodeExpansion() {
-      this.isCodeExpanded = !this.isCodeExpanded;
     },
   },
 };
@@ -110,94 +75,20 @@ export default {
 .submission-error-dropdown {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 36px;
 }
 
 .sub-title {
   font-size: 14px;
   font-weight: bold;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
 .error-message {
   /deep/ .code-highlight-wrapper {
-    max-width: 100%;
+    // max-width: 100%;
     max-height: 300px;
     overflow: auto;
-  }
-}
-
-.failed-tc-header {
-  display: flex;
-  align-items: center;
-  margin-bottom: 6px;
-  font-weight: bold;
-  gap: 8px;
-}
-
-.testcase-info {
-  display: flex;
-  justify-content: space-between;
-  align-items: stretch;
-  gap: 16px;
-
-  p {
-    font-size: 13px;
-    font-weight: bold;
-    margin-bottom: 8px;
-  }
-}
-
-.testcase-input,
-.testcase-output {
-  flex: 1;
-  max-width: 50%;
-  display: flex;
-  flex-direction: column;
-
-  /deep/ .code-highlight-wrapper {
-    flex: 1;
-    max-width: 100%;
-    max-height: 300px;
-    overflow: auto;
-  }
-}
-
-.submission-code-section {
-  .code-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 8px;
-
-    .expand-hint {
-      font-size: 11px;
-      color: var(--text-color);
-      font-style: italic;
-    }
-  }
-
-  .code-wrapper {
-    cursor: pointer;
-    transition: all 0.3s ease;
-    border-radius: 4px;
-
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.02);
-    }
-
-    /deep/ .code-highlight-wrapper {
-      max-width: 100%;
-      max-height: 300px;
-      overflow: hidden;
-      transition: max-height 0.3s ease;
-    }
-
-    &.expanded {
-      /deep/ .code-highlight-wrapper {
-        max-height: none;
-      }
-    }
   }
 }
 </style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionRow.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionRow.vue
@@ -1,0 +1,166 @@
+<template>
+  <tr
+    class="submission-row"
+    :class="{ selected: isSelected }"
+    @click="$emit('click')"
+  >
+    <td>{{ index }}</td>
+    <td class="status-cell">
+      <span
+        class="status-dot"
+        :style="{ backgroundColor: judgeStatus[submission.result].color }"
+      />
+      <span class="status">{{ judgeStatus[submission.result].name }}</span>
+    </td>
+    <td>
+      <span
+        class="language-pill"
+        :style="getLanguageStyle(submission.language)"
+      >
+        {{ submission.language }}
+      </span>
+    </td>
+    <td>
+      <Icon type="ios-speedometer-outline" />
+      {{ formatTimeCost(submission.statistic_info.time_cost) }}
+    </td>
+    <td>
+      <Icon type="ios-pulse" />
+      {{ formatMemoryCost(submission.statistic_info.memory_cost) }}
+    </td>
+    <td>{{ formatTime(submission.create_time) }}</td>
+    <td>
+      <Icon
+        :type="isSelected ? 'ios-arrow-up' : 'ios-arrow-down'"
+        :class="{ 'rotate-icon': isSelected }"
+      />
+    </td>
+  </tr>
+</template>
+
+<script>
+import {
+  JUDGE_STATUS,
+  LANGUAGE_COLOR,
+} from "../../../../../../utils/constants";
+
+const BYTES_IN_KB = 1024;
+const BYTES_IN_MB = BYTES_IN_KB * 1024;
+const BYTES_IN_GB = BYTES_IN_MB * 1024;
+
+export default {
+  name: "SubmissionRow",
+  props: {
+    submission: {
+      type: Object,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+    isSelected: {
+      type: Boolean,
+      default: false,
+    },
+    isDarkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      judgeStatus: JUDGE_STATUS,
+    };
+  },
+  methods: {
+    formatTime(timestamp) {
+      return new Date(timestamp).toLocaleDateString();
+    },
+
+    formatTimeCost(time) {
+      return time != null ? `${time} ms` : "N/A";
+    },
+
+    formatMemoryCost(memory) {
+      if (memory == null) return "N/A";
+
+      if (memory < BYTES_IN_MB) {
+        return `${Math.round(memory / BYTES_IN_KB)} KB`;
+      }
+      if (memory < BYTES_IN_GB) {
+        return `${(memory / BYTES_IN_MB).toFixed(2)} MB`;
+      }
+      return `${(memory / BYTES_IN_GB).toFixed(2)} GB`;
+    },
+
+    getLanguageStyle(language) {
+      const colorConfig = LANGUAGE_COLOR[language];
+      if (!colorConfig) return {};
+
+      const themeConfig = this.isDarkMode
+        ? colorConfig.darkTheme
+        : colorConfig.lightTheme;
+      return {
+        backgroundColor: themeConfig.color,
+        color: themeConfig.textColor,
+      };
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+.submission-row {
+  transition: background 0.2s;
+  padding: 0 12px;
+  cursor: pointer;
+
+  td {
+    text-align: start;
+    vertical-align: middle;
+    padding: 12px 14px;
+    font-size: 14px;
+
+    &:first-child {
+      min-width: 20px;
+      max-width: 40px;
+    }
+  }
+
+  &.selected {
+    background: var(--row-hover-bg);
+    transition: background 0.5s;
+  }
+
+  &:hover {
+    background: var(--row-hover-bg);
+  }
+}
+
+.status-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status {
+  font-weight: bold;
+}
+
+.language-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 10.5px;
+  font-weight: bold;
+}
+</style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionStats.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/SubmissionStats.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="submission-stats">
+    <p class="sub-title">제출 분석</p>
+    <div class="stats-grid">
+      <div class="stat-box">
+        <p class="stat-label">제출 순위</p>
+        <div class="stat-value">
+          <span class="prefix">#</span>
+          <span class="value">{{ stats.solvedRank || "0" }}</span>
+        </div>
+      </div>
+      <div class="stat-box">
+        <p class="stat-label">시간 비용</p>
+        <div class="stat-value">
+          <span class="prefix">상위</span>
+          <span class="value">{{ stats.timeCostPercent || "0" }}</span>
+          <span class="suffix">%</span>
+        </div>
+      </div>
+      <div class="stat-box">
+        <p class="stat-label">메모리 비용</p>
+        <div class="stat-value">
+          <span class="prefix">상위</span>
+          <span class="value">{{ stats.memoryCostPercent || "0" }}</span>
+          <span class="suffix">%</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "SubmissionStats",
+  props: {
+    stats: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+.submission-stats {
+  .sub-title {
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 12px;
+  }
+
+  .stats-grid {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .stat-box {
+    flex: 1;
+    text-align: center;
+    padding: 16px 12px;
+    border-radius: 8px;
+    background-color: var(--dropdown-bg);
+    color: var(--dropdown-text);
+    border: 1px solid var(--border-color);
+    box-shadow: var(--box-shadow);
+    transition: all 0.2s ease;
+
+    &:hover {
+      box-shadow: var(--box-shadow-hover);
+    }
+  }
+
+  .stat-label {
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
+
+  .stat-value {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    margin-top: 4px;
+  }
+
+  .prefix,
+  .suffix {
+    font-size: 12px;
+    font-weight: normal;
+  }
+
+  .value {
+    font-size: 24px;
+    font-weight: bold;
+  }
+}
+</style>

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/TestCaseInfo.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/TestCaseInfo.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="testcase-info">
+    <div class="testcase-header">
+      <p class="sub-title">최초 실패 케이스</p>
+      <CustomTooltip
+        content="테스트케이스 중 최초로 실패한 케이스의 입력값과 기대값입니다."
+        placement="right"
+      >
+        <Icon type="ios-information" />
+      </CustomTooltip>
+    </div>
+    <div class="testcase-content">
+      <div class="testcase-section">
+        <p class="testcase-label">입력값</p>
+        <CodeHighlight
+          type="plaintext"
+          :code="testCase.input || ''"
+          :isDarkMode="isDarkMode"
+        />
+      </div>
+      <div class="testcase-section">
+        <p class="testcase-label">기대값</p>
+        <CodeHighlight
+          type="plaintext"
+          :code="testCase.output || ''"
+          :isDarkMode="isDarkMode"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import CodeHighlight from "./CodeHighlight.vue";
+import CustomTooltip from "@oj/components/CustomTooltip";
+
+export default {
+  name: "TestCaseInfo",
+  components: {
+    CodeHighlight,
+    CustomTooltip,
+  },
+  props: {
+    testCase: {
+      type: Object,
+      required: true,
+    },
+    isDarkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+.testcase-info {
+  .testcase-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+
+    .sub-title {
+      font-size: 14px;
+      font-weight: bold;
+    }
+  }
+
+  .testcase-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .testcase-section {
+    flex: 1;
+    max-width: 50%;
+    display: flex;
+    flex-direction: column;
+
+    .testcase-label {
+      font-size: 13px;
+      font-weight: bold;
+      margin-bottom: 8px;
+    }
+
+    /deep/ .code-highlight-wrapper {
+      flex: 1;
+      max-width: 100%;
+      max-height: 300px;
+      overflow: auto;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
# Changelog
아래와 같이 제출 현황에 대한 컴포넌트를 구조화하였습니다.
<img width="1605" height="540" alt="image" src="https://github.com/user-attachments/assets/60f5fdd3-94cb-47c9-8eef-05080eec438f" />

# Testing
- 제출 목록
<img width="1705" height="1015" alt="image" src="https://github.com/user-attachments/assets/67c09a07-13aa-473d-b90c-39faf9e8c2b0" />
- 실패한 제출 드롭다운
<img width="1703" height="1013" alt="image" src="https://github.com/user-attachments/assets/5eaa6b31-3b76-40d1-948b-d76fb9594bbc" />
- 성공한 제출 드롭다운
<img width="1701" height="1011" alt="image" src="https://github.com/user-attachments/assets/93f30fce-9456-4196-bcae-6382f93600d0" />

# Ops Impact
N/A

# Version Compatibility
N/A