### PR TITLE
#413 CodeMirror 높이 오류 수정

### DIFF
--- a/frontend/src/pages/admin/components/CodeMirror.vue
+++ b/frontend/src/pages/admin/components/CodeMirror.vue
@@ -63,7 +63,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .CodeMirror {
     height: auto !important;
   }


### PR DESCRIPTION
# Changelog
- `src/pages/admin/components/CodeMirror.vue` 에 있는 style이 scoped로 설정되어 있지 않고, `.CodeMirror-scroll`의 max-height를 1000px로 설정하고 있어 아래와 같이 화면이 큰 경우에 전체를 차지하지 않는 오류가 발생하였습니다.
<img width="2987" height="1650" alt="image" src="https://github.com/user-attachments/assets/c37a55b2-aef0-4ba0-a559-ed9d93a527d1" />

- 따라서 해당 style을 scoped로 처리하여 다른 컴포넌트의 스타일에 영향을 주지 않도록 설정하였습니다.

# Testing
- 로컬에서 테스트
<img width="2986" height="1646" alt="image" src="https://github.com/user-attachments/assets/c0bf5abb-d0c8-4403-95f4-03f80a80fdaa" />

# Ops Impact
N/A

# Version Compatibility
N/A