### PR TITLE
#439 Simditor 언어 영어로 변환

### DIFF
--- a/frontend/src/pages/admin/components/Simditor.vue
+++ b/frontend/src/pages/admin/components/Simditor.vue
@@ -51,6 +51,8 @@ export default {
     }
   },
   mounted() {
+    Simditor.locale = "en-US"
+
     this.editor = new Simditor({
       textarea: this.$refs.editor,
       toolbar: this.toolbar,

--- a/frontend/src/pages/admin/components/Simditor.vue
+++ b/frontend/src/pages/admin/components/Simditor.vue
@@ -51,7 +51,7 @@ export default {
     }
   },
   mounted() {
-    Simditor.locale = "en-US"
+    Simditor.locale = "en-US" // 한국어는 지원하지 않으므로 영어로 설정합니다.
 
     this.editor = new Simditor({
       textarea: this.$refs.editor,


### PR DESCRIPTION
# Changelog
- Simditor의 언어 기본값이 중국어인데 이해하기 힘들어서 영어로 변경하였습니다. (아쉽게도 한국어는 지원하지 않습니다ㅜㅡㅜ)

# Testing
- 문제 수정 탭에서 옵션이 영어로 표시되는지 확인
<img width="1120" height="416" alt="image" src="https://github.com/user-attachments/assets/28800181-e992-464e-8f33-ff6f9423aaeb" />

# Ops Impact
N/A

# Version Compatibility
N/A