### PR TITLE
#444 모니터링 Docker Stack 생성

### DIFF
--- a/deployment/docker-compose.monitoring.yml
+++ b/deployment/docker-compose.monitoring.yml
@@ -21,7 +21,7 @@ services:
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk
+      - /dev/disk/:/dev/disk:ro
     deploy:
       mode: global
       restart_policy:
@@ -34,7 +34,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ${PWD}/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
     deploy:
       replicas: 1

--- a/deployment/docker-compose.monitoring.yml
+++ b/deployment/docker-compose.monitoring.yml
@@ -1,0 +1,65 @@
+version: "3.9"
+
+networks:
+  monitoring:
+    driver: overlay
+    attachable: true
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+services:
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.0
+    networks:
+      - monitoring
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+
+  prometheus:
+    image: prom/prometheus:v3.5.0
+    networks:
+      - monitoring
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - cadvisor
+
+  grafana:
+    image: grafana/grafana:11.6.3
+    networks:
+      - monitoring
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - prometheus

--- a/deployment/prometheus.yml
+++ b/deployment/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "cadvisor"
+    dns_sd_configs:
+      - names:
+          - "tasks.cadvisor"
+        type: "A"
+        port: 8080


### PR DESCRIPTION
# Changelog
- 모니터링 전용 Docker network인 `monitoring`을 생성하였습니다.
- 컨테이너의 메트릭을 수집하고 시각화하기 위한 모니터링 Docker Stack을 구성하였습니다.
  - `cadvisor`: **Docker 컨테이너의 메트릭을 수집**하여 Prometheus가 가져갈 수 있도록 노출하는 에이전트입니다.
    - version: 0.52.0
    - port: 8080
  - `prometheus`: cadvisor가 수집한 메트릭을 수집하여 **시계열 데이터로 저장**합니다.
    - version: 3.5.0
    - port: 9090
  - `grafana`: prometheus가 수집한 메트릭을 **시각화**합니다.
    - version: 11.6.3
    - port: 3000

# Testing
- Docker Stack 생성 결과
<img width="948" height="257" alt="image" src="https://github.com/user-attachments/assets/04b1a705-ef23-4e7a-a7d6-efe53015f9ba" />

- `cadvisor`
<img width="1183" height="950" alt="localhost_8080_containers_" src="https://github.com/user-attachments/assets/34e8de07-4437-41c4-ac60-1a19944b5693" />

- `prometheus`
<img width="1196" height="962" alt="127 0 0 1_9090_targets" src="https://github.com/user-attachments/assets/0948f1d7-1d9a-4f66-8786-ff310d88a0ec" />

- `grafana`
<img width="1190" height="958" alt="127 0 0 1_3000_d_fevqyyi9khiioe_docker-monitoring_orgId=1 from=now-3h to=now timezone=browser refresh=10s" src="https://github.com/user-attachments/assets/090cd6f5-36c7-466c-85c3-a4b4a49953ac" />

# Ops Impact
N/A

# Version Compatibility
N/A