### PR TITLE
#446 불필요한 포트 매핑 제거

### DIFF
--- a/deployment/docker-compose.monitoring.yml
+++ b/deployment/docker-compose.monitoring.yml
@@ -14,8 +14,6 @@ services:
     image: gcr.io/cadvisor/cadvisor:v0.52.0
     networks:
       - monitoring
-    ports:
-      - "8080:8080"
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw
@@ -31,8 +29,6 @@ services:
     image: prom/prometheus:v3.5.0
     networks:
       - monitoring
-    ports:
-      - "9090:9090"
     volumes:
       - ${PWD}/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus


### PR DESCRIPTION
# Changelog
- 모니터링은 `cadvisor` -> `prometheus` -> `grafana`로 구성되어 있습니다. 하지만 `grafana`이외에 다른 서비스는 외부에서 접근할 필요가 없는 서비스들이므로 포트 매핑을 제거하였습니다.

# Testing
모니터링 기능 정상 작동 여부 확인
<img width="1689" height="1056" alt="image" src="https://github.com/user-attachments/assets/200f3d10-0947-4f7d-b25d-7ae32d342c8b" />

# Ops Impact
N/A

# Version Compatibility
N/A