### PR TITLE
#457 채점 서버 버전 1.0.1로 변경

### DIFF
--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
     image: registry.code-place-dev.site/code-place-dev/backend:latest
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.0-beta
+    image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.1
 
   oj-postgres:
     ports:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
         condition: on-failure
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.0-beta
+    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.1
     deploy:
       replicas: 6
       update_config:
@@ -62,11 +62,11 @@ services:
         condition: on-failure
       resources:
         limits:
-          cpus: "0.50"
+          cpus: "1.00"
           memory: 1GB
         reservations:
-          cpus: "0.10"
-          memory: 300M
+          cpus: "1.00"
+          memory: 1GB
 
   oj-postgres:
     ports:


### PR DESCRIPTION
# Changelog
- 채점 서버 버전을 1.0.0-beta -> 1.0.1 로 변경하였습니다.
  - 1.0.1 버전은 비정상적인 시간 측정을 해결하는 변경사항을 포함하고 있습니다.
    - 관련 PR: https://github.com/pnu-code-place/JudgeServer/pull/2
- Production 스택에서 안정적인 채점을 위해 `vCPU=1.00`, `memory=1GB` 로 고정하였습니다.

# Testing
N/A

# Ops Impact
N/A

# Version Compatibility
N/A