### PR TITLE
#463 대회 정보 변경 시 붙여넣기 허용 여부가 변경되지 않는 오류 수정

### DIFF
--- a/backend/contest/serializers.py
+++ b/backend/contest/serializers.py
@@ -39,6 +39,7 @@ class EditConetestSeriaizer(serializers.Serializer):
     password = serializers.CharField(allow_blank=True, allow_null=True, max_length=32)
     visible = serializers.BooleanField()
     real_time_rank = serializers.BooleanField()
+    allow_paste = serializers.BooleanField()
     allowed_ip_ranges = serializers.ListField(child=serializers.CharField(max_length=32))
 
 


### PR DESCRIPTION
# Changelog
#464 를 급하게 머지하는 과정에서 PUT 요청에 대해서도 처리하는 걸 깜빡했습니다..

- `EditContestSerializer`에 `allow_paste`를 추가하여 클라이언트에서 전달되는 `allow_paste`값은 정상적으로 받을 수 있도록 변경하였습니다.

# Testing
- 로컬에서 변경 사항이 잘 적용되는지 여부 테스트
https://github.com/user-attachments/assets/e7611360-139b-4db2-a176-b96d7c79479f

# Ops Impact
N/A

# Version Compatibility
N/A