### PR TITLE
#NOISSUE 로컬 환경에서 데이터베이스 생성 시 디렉토리 바인딩

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -72,6 +72,8 @@ data/public/avatar/*
 data/public/banner/*
 data/public/popup/*
 data/config/*
+data/postgres/*
+data/redis/*
 !data/config/.gitkeep
 
 http_locations.conf

--- a/backend/init_db.sh
+++ b/backend/init_db.sh
@@ -16,8 +16,8 @@ fi
 
 sleep 2
 docker rm -f oj-postgres-dev oj-redis-dev
-docker run -it -d -e POSTGRES_DB=onlinejudge -e POSTGRES_USER=onlinejudge -e POSTGRES_PASSWORD=onlinejudge -p 127.0.0.1:5435:5432 --name oj-postgres-dev postgres:10
-docker run -it -d -p 127.0.0.1:6380:6379 --name oj-redis-dev redis:4.0-alpine
+docker run -it -d -e POSTGRES_DB=onlinejudge -e POSTGRES_USER=onlinejudge -e POSTGRES_PASSWORD=onlinejudge -p 127.0.0.1:5435:5432 --name oj-postgres-dev -v ./data/postgres:/var/lib/postgresql/data postgres:10
+docker run -it -d -p 127.0.0.1:6380:6379 --name oj-redis-dev -v ./data/redis:/data redis:4.0-alpine
 
 if [ "$1" = "--migrate" ]; then
     sleep 3


### PR DESCRIPTION
# Changelog
로컬에서 테스트하다가 데이터를 날리게 되면 생각보다 꽤 번거롭고 화가 납니다...ㅎ_ㅎ
따라서 로컬에서도 실수로 컨테이너를 삭제했을 때 데이터를 잃지 않도록 바인딩을 추가했습니다.

- `init_db.sh`에 postgres, redis에 대한 디렉토리 바인딩을 추가했습니다.
  - postgres: `backend/data/postgres`
  - redis: `backend/data/redis`

# Testing
- `init_db.sh` 실행 후 `backend/data/` 디렉토리에서 바인딩 여부 확인
<img width="309" height="493" alt="image" src="https://github.com/user-attachments/assets/572b7786-dd98-4d59-9d5c-74f9285fbf49" />

# Ops Impact
N/A

# Version Compatibility
N/A