### PR TITLE
#462 채점 서버 버전 1.0.1 -> 1.0.2 업그레이드

### DIFF
--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
     image: registry.code-place-dev.site/code-place-dev/backend:latest
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.1
+    image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.2
 
   oj-postgres:
     ports:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
         condition: on-failure
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.1
+    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.2
     deploy:
       replicas: 6
       update_config:


### PR DESCRIPTION
# Changelog
- 채점 서버 버전을 1.0.1에서 1.0.2로 업그레이드하였습니다.
  - 1.0.2의 변경사항은 https://github.com/pnu-code-place/JudgeServer/pull/3 를 참고하세요.

# Testing
N/A

# Ops Impact
N/A

# Version Compatibility
N/A