### PR TITLE
fix: 도메인을 code-place-dev.site에서 code-place-dev.kr로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > 운영 서버 주소 : https://code.pusan.ac.kr/
 >
-> 개발(베타) 서버 주소 : [https://code-place-dev.site/](https://k3s.code-place-dev.site/)
+> 개발(베타) 서버 주소 : [https://code-place-dev.kr/](https://k3s.code-place-dev.kr/)
 
 <br/>
 

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -2,28 +2,28 @@ version: "3.9"
 
 services:
   frontend:
-    image: registry.code-place-dev.site/code-place-dev/frontend:latest
+    image: registry.code-place-dev.kr/code-place-dev/frontend:latest
     ports:
       - "8001:8000"
       - "1444:1443"
     volumes:
-      - /etc/letsencrypt/live/code-place-dev.site/fullchain.pem:/etc/letsencrypt/live/code-place-dev.site/fullchain.pem:ro
-      - /etc/letsencrypt/live/code-place-dev.site/privkey.pem:/etc/letsencrypt/live/code-place-dev.site/privkey.pem:ro
+      - /etc/letsencrypt/live/code-place-dev.kr/fullchain.pem:/etc/letsencrypt/live/code-place-dev.kr/fullchain.pem:ro
+      - /etc/letsencrypt/live/code-place-dev.kr/privkey.pem:/etc/letsencrypt/live/code-place-dev.kr/privkey.pem:ro
       - data_volume:/data:ro
 
   backend:
-    image: registry.code-place-dev.site/code-place-dev/backend:latest
+    image: registry.code-place-dev.kr/code-place-dev/backend:latest
     volumes:
       - data_volume:/data:rw
 
   celery-beat:
-    image: registry.code-place-dev.site/code-place-dev/backend:latest
+    image: registry.code-place-dev.kr/code-place-dev/backend:latest
 
   celery-worker:
-    image: registry.code-place-dev.site/code-place-dev/backend:latest
+    image: registry.code-place-dev.kr/code-place-dev/backend:latest
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.2
+    image: registry.code-place-dev.kr/code-place-dev/judge-server:1.0.2
 
   oj-postgres:
     ports:

--- a/deployment/docker-compose.hub.yml
+++ b/deployment/docker-compose.hub.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   auth-server:
-    image: registry.code-place-dev.site/code-place-hub/auth-server:latest
+    image: registry.code-place-dev.kr/code-place-hub/auth-server:latest
     ports:
       - "3444:80"
     env_file:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   frontend:
-    image: registry.code-place-dev.site/code-place-prod/frontend:latest
+    image: registry.code-place-dev.kr/code-place-prod/frontend:latest
     ports:
       - "8000:8000"
       - "1443:1443"
@@ -20,7 +20,7 @@ services:
         order: start-first
 
   backend:
-    image: registry.code-place-dev.site/code-place-prod/backend:latest
+    image: registry.code-place-dev.kr/code-place-prod/backend:latest
     volumes:
       - data_volume:/data:rw
     deploy:
@@ -32,7 +32,7 @@ services:
         condition: on-failure
 
   celery-beat:
-    image: registry.code-place-dev.site/code-place-prod/backend:latest
+    image: registry.code-place-dev.kr/code-place-prod/backend:latest
     deploy:
       replicas: 1
       update_config:
@@ -42,7 +42,7 @@ services:
         condition: on-failure
 
   celery-worker:
-    image: registry.code-place-dev.site/code-place-prod/backend:latest
+    image: registry.code-place-dev.kr/code-place-prod/backend:latest
     deploy:
       replicas: 6 # NOTE: Match judge-server replicas after switching to one worker process per container.
       update_config:
@@ -52,7 +52,7 @@ services:
         condition: on-failure
 
   oj-judge:
-    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.2
+    image: registry.code-place-dev.kr/code-place-prod/judge-server:1.0.2
     deploy:
       replicas: 6
       update_config:

--- a/frontend/deploy/swarm/web-frontend.yml
+++ b/frontend/deploy/swarm/web-frontend.yml
@@ -12,10 +12,10 @@ services:
       - data_volume:/data:ro
       - /etc/letsencrypt/live/code.pusan.ac.kr/fullchain.pem:/etc/letsencrypt/live/code.pusan.ac.kr/fullchain.pem:ro
       - /etc/letsencrypt/live/code.pusan.ac.kr/privkey.pem:/etc/letsencrypt/live/code.pusan.ac.kr/privkey.pem:ro
-      - /etc/letsencrypt/live/code-place-dev.site/fullchain.pem:/etc/letsencrypt/live/code-place-dev.site/fullchain.pem:ro
-      - /etc/letsencrypt/live/code-place-dev.site/privkey.pem:/etc/letsencrypt/live/code-place-dev.site/privkey.pem:ro
-      - /etc/letsencrypt/live/registry.code-place-dev.site/fullchain.pem:/etc/letsencrypt/live/registry.code-place-dev.site/fullchain.pem:ro
-      - /etc/letsencrypt/live/registry.code-place-dev.site/privkey.pem:/etc/letsencrypt/live/registry.code-place-dev.site/privkey.pem:ro
+      - /etc/letsencrypt/live/code-place-dev.kr/fullchain.pem:/etc/letsencrypt/live/code-place-dev.kr/fullchain.pem:ro
+      - /etc/letsencrypt/live/code-place-dev.kr/privkey.pem:/etc/letsencrypt/live/code-place-dev.kr/privkey.pem:ro
+      - /etc/letsencrypt/live/registry.code-place-dev.kr/fullchain.pem:/etc/letsencrypt/live/registry.code-place-dev.kr/fullchain.pem:ro
+      - /etc/letsencrypt/live/registry.code-place-dev.kr/privkey.pem:/etc/letsencrypt/live/registry.code-place-dev.kr/privkey.pem:ro
     networks:
       - prod-network
 

--- a/hub/scripts/authorize.js
+++ b/hub/scripts/authorize.js
@@ -11,7 +11,7 @@ const localAuth = {
     this.KEY = "CodePlaceHub_token";
     // TODO: Change ACCESS_TOKEN_URL to the correct one. This is for testing.
     this.ACCESS_TOKEN_URL =
-      "https://hub-auth.code-place-dev.site/api/token/issue";
+      "https://hub-auth.code-place-dev.kr/api/token/issue";
     this.AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
     this.REDIRECT_URL = "https://github.com/"; // for example, https://github.com
     this.SCOPES = ["repo"];

--- a/hub/scripts/oauth2.js
+++ b/hub/scripts/oauth2.js
@@ -7,7 +7,7 @@ const oAuth2 = {
     this.KEY = "CodePlaceHub_token";
     // TODO: Change ACCESS_TOKEN_URL to the correct one. This is for testing.
     this.ACCESS_TOKEN_URL =
-      "https://hub-auth.code-place-dev.site/api/token/issue";
+      "https://hub-auth.code-place-dev.kr/api/token/issue";
     this.AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
     this.CLIENT_ID = "Ov23liGMeecEJnH8nRfD"; // Code Place Hub OAuth App ID
     this.REDIRECT_URL = "https://github.com/"; // for example, https://github.com

--- a/kubernetes/monitoring/alertmanager-config.yaml
+++ b/kubernetes/monitoring/alertmanager-config.yaml
@@ -84,14 +84,14 @@ spec:
             우선순위: P0
             네임스페이스: {{ .CommonLabels.namespace }}
             {{ if match "^code-place-(dev|prod)$" .CommonLabels.namespace }}
-            개요: https://monitoring.code-place-dev.site/d/codeplace-overview/codeplace-overview?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
-            로그: https://monitoring.code-place-dev.site/d/codeplace-logs/codeplace-logs?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
+            개요: https://monitoring.code-place-dev.kr/d/codeplace-overview/codeplace-overview?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
+            로그: https://monitoring.code-place-dev.kr/d/codeplace-logs/codeplace-logs?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
             {{ end }}
             {{ if eq .CommonLabels.namespace "longhorn-system" }}
-            스토리지(prod): https://monitoring.code-place-dev.site/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=prod
-            스토리지(dev): https://monitoring.code-place-dev.site/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=dev
+            스토리지(prod): https://monitoring.code-place-dev.kr/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=prod
+            스토리지(dev): https://monitoring.code-place-dev.kr/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=dev
             {{ end }}
-            모니터링: https://monitoring.code-place-dev.site/d/codeplace-monitoring-stack/codeplace-monitoring-stack?orgId=1
+            모니터링: https://monitoring.code-place-dev.kr/d/codeplace-monitoring-stack/codeplace-monitoring-stack?orgId=1
             {{ with index .Alerts 0 }}발생 쿼리: [Prometheus에서 보기]({{ .GeneratorURL }}){{ end }}
           username: CodePlace Alertmanager
     - name: dev-p1-muted
@@ -115,13 +115,13 @@ spec:
             우선순위: P1
             네임스페이스: {{ .CommonLabels.namespace }}
             {{ if match "^code-place-(dev|prod)$" .CommonLabels.namespace }}
-            개요: https://monitoring.code-place-dev.site/d/codeplace-overview/codeplace-overview?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
-            로그: https://monitoring.code-place-dev.site/d/codeplace-logs/codeplace-logs?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
+            개요: https://monitoring.code-place-dev.kr/d/codeplace-overview/codeplace-overview?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
+            로그: https://monitoring.code-place-dev.kr/d/codeplace-logs/codeplace-logs?orgId=1&var-environment={{ reReplaceAll "^code-place-" "" .CommonLabels.namespace }}
             {{ end }}
             {{ if eq .CommonLabels.namespace "longhorn-system" }}
-            스토리지(prod): https://monitoring.code-place-dev.site/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=prod
-            스토리지(dev): https://monitoring.code-place-dev.site/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=dev
+            스토리지(prod): https://monitoring.code-place-dev.kr/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=prod
+            스토리지(dev): https://monitoring.code-place-dev.kr/d/codeplace-storage/codeplace-storage?orgId=1&var-environment=dev
             {{ end }}
-            모니터링: https://monitoring.code-place-dev.site/d/codeplace-monitoring-stack/codeplace-monitoring-stack?orgId=1
+            모니터링: https://monitoring.code-place-dev.kr/d/codeplace-monitoring-stack/codeplace-monitoring-stack?orgId=1
             {{ with index .Alerts 0 }}발생 쿼리: [Prometheus에서 보기]({{ .GeneratorURL }}){{ end }}
           username: CodePlace Alertmanager

--- a/kubernetes/monitoring/kube-prometheus-stack-values.yaml
+++ b/kubernetes/monitoring/kube-prometheus-stack-values.yaml
@@ -148,10 +148,10 @@ grafana:
     annotations:
       traefik.ingress.kubernetes.io/router.tls.certresolver: default
     hosts:
-      - monitoring.code-place-dev.site
+      - monitoring.code-place-dev.kr
     tls:
       - hosts:
-          - monitoring.code-place-dev.site
+          - monitoring.code-place-dev.kr
   sidecar:
     dashboards:
       enabled: true

--- a/kubernetes/monitoring/prometheus-rules.test.yaml
+++ b/kubernetes/monitoring/prometheus-rules.test.yaml
@@ -9,11 +9,11 @@ tests:
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1 1 1 1 1 1 1 1'
     alert_rule_test:
       - eval_time: 3m
@@ -28,11 +28,11 @@ tests:
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1'
-      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.kr/healthz"}'
         values: '0 0 0 0 0 0'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1'
     alert_rule_test:
       - eval_time: 1m15s
@@ -40,7 +40,7 @@ tests:
         exp_alerts:
           - exp_labels:
               environment: prod
-              instance: https://hub-auth.code-place-dev.site/healthz
+              instance: https://hub-auth.code-place-dev.kr/healthz
               namespace: code-place-prod
               priority: P0
               probe_type: public-http
@@ -48,18 +48,18 @@ tests:
               severity: critical
             exp_annotations:
               summary: 운영 hub-auth 공개 엔드포인트가 응답하지 않습니다
-              description: https://hub-auth.code-place-dev.site/healthz의 HTTPS 가상 점검이 1분 동안 실패했습니다.
+              description: https://hub-auth.code-place-dev.kr/healthz의 HTTPS 가상 점검이 1분 동안 실패했습니다.
 
   - name: transient prod failure recovers before the one minute threshold
     interval: 15s
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.kr/healthz"}'
         values: '0 0 0 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1 1'
     alert_rule_test:
       - eval_time: 1m30s
@@ -71,11 +71,11 @@ tests:
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '0 0 0 0 0 0 0 0 0 0'
     alert_rule_test:
       - eval_time: 1m45s
@@ -86,7 +86,7 @@ tests:
         exp_alerts:
           - exp_labels:
               environment: dev
-              instance: https://hub-auth-dev.code-place-dev.site/healthz
+              instance: https://hub-auth-dev.code-place-dev.kr/healthz
               namespace: code-place-dev
               priority: P1
               probe_type: public-http
@@ -94,16 +94,16 @@ tests:
               severity: warning
             exp_annotations:
               summary: 개발 hub-auth 공개 엔드포인트가 응답하지 않습니다
-              description: https://hub-auth-dev.code-place-dev.site/healthz의 HTTPS 가상 점검이 2분 동안 실패했습니다.
+              description: https://hub-auth-dev.code-place-dev.kr/healthz의 HTTPS 가상 점검이 2분 동안 실패했습니다.
 
   - name: missing prod hub-auth telemetry is not endpoint downtime
     interval: 15s
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1 1 1 1 1'
     alert_rule_test:
       - eval_time: 2m15s
@@ -128,11 +128,11 @@ tests:
     input_series:
       - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="frontend",instance="https://code.pusan.ac.kr/"}'
         values: '1 1 1 1 1 1'
-      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="prod",namespace="code-place-prod",probe_type="public-http",service="hub-auth",instance="https://hub-auth.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.site/"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="frontend",instance="https://k3s.code-place-dev.kr/"}'
         values: '1 1 1 1 1 1'
-      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.site/healthz"}'
+      - series: 'probe_success{environment="dev",namespace="code-place-dev",probe_type="public-http",service="hub-auth",instance="https://hub-auth-dev.code-place-dev.kr/healthz"}'
         values: '1 1 1 1 1 1'
       - series: 'probe_success{environment="prod",namespace="another-system",probe_type="public-http",service="hub-auth",instance="https://example.invalid/"}'
         values: '0 0 0 0 0 0'

--- a/kubernetes/monitoring/public-endpoint-probes.yaml
+++ b/kubernetes/monitoring/public-endpoint-probes.yaml
@@ -14,7 +14,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://k3s.code-place-dev.site/
+        - https://k3s.code-place-dev.kr/
       labels:
         environment: dev
         namespace: code-place-dev
@@ -60,7 +60,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://monitoring.code-place-dev.site/
+        - https://monitoring.code-place-dev.kr/
       labels:
         environment: monitoring
         namespace: monitoring
@@ -83,7 +83,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://hub-auth-dev.code-place-dev.site/healthz
+        - https://hub-auth-dev.code-place-dev.kr/healthz
       labels:
         environment: dev
         namespace: code-place-dev
@@ -106,7 +106,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://hub-auth.code-place-dev.site/healthz
+        - https://hub-auth.code-place-dev.kr/healthz
       labels:
         environment: prod
         namespace: code-place-prod

--- a/kubernetes/monitoring/validate_alerts.py
+++ b/kubernetes/monitoring/validate_alerts.py
@@ -389,7 +389,7 @@ def main() -> int:
         for environment in ("prod", "dev"):
             storage_link = (
                 f"스토리지({environment}): "
-                "https://monitoring.code-place-dev.site/d/codeplace-storage/"
+                "https://monitoring.code-place-dev.kr/d/codeplace-storage/"
                 f"codeplace-storage?orgId=1&var-environment={environment}"
             )
             if storage_link not in message:

--- a/kubernetes/overlays/dev/backend-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/backend-deployment-patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: backend
           env:
             - name: CSRF_TRUSTED_ORIGINS
-              value: "https://k3s.code-place-dev.site"
+              value: "https://k3s.code-place-dev.kr"
             - name: SENTRY_DSN_BACKEND
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/dev/frontend-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/frontend-deployment-patch.yaml
@@ -11,4 +11,4 @@ spec:
             - name: FORCE_HTTPS
               value: "0"
             - name: SERVER_NAME
-              value: "k3s.code-place-dev.site" # NOTE: 임시 K3s 테스트용 도메인 주소입니다. 추후 수정 예정입니다. (Junwoo)
+              value: "k3s.code-place-dev.kr" # NOTE: 임시 K3s 테스트용 도메인 주소입니다. 추후 수정 예정입니다. (Junwoo)

--- a/kubernetes/overlays/dev/frontend-ingress-patch.yaml
+++ b/kubernetes/overlays/dev/frontend-ingress-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frontend-ingress
 spec:
   rules:
-    - host: k3s.code-place-dev.site
+    - host: k3s.code-place-dev.kr
       http:
         paths:
           - path: /
@@ -16,4 +16,4 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - k3s.code-place-dev.site
+        - k3s.code-place-dev.kr

--- a/kubernetes/overlays/dev/hub-auth-ingress-patch.yaml
+++ b/kubernetes/overlays/dev/hub-auth-ingress-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hub-auth-ingress
 spec:
   rules:
-    - host: hub-auth-dev.code-place-dev.site
+    - host: hub-auth-dev.code-place-dev.kr
       http:
         paths:
           - path: /
@@ -17,5 +17,5 @@ spec:
   tls:
     - hosts:
         # NOTE: 굳이 `hub-auth-dev` 라고 명시한 이유는 production과 dev 환경을 구분하기 위해서입니다.
-        # 현재 사용할 수 있는 도메인이 code-place-dev.site 뿐이기 때문에 production과 구분하기 위해서는 dev라는 것을 명시하는 것이 좋다고 판단했습니다. (Junwoo)
-        - hub-auth-dev.code-place-dev.site
+        # 현재 사용할 수 있는 도메인이 code-place-dev.kr 뿐이기 때문에 production과 구분하기 위해서는 dev라는 것을 명시하는 것이 좋다고 판단했습니다. (Junwoo)
+        - hub-auth-dev.code-place-dev.kr

--- a/kubernetes/overlays/dev/kustomization.yaml
+++ b/kubernetes/overlays/dev/kustomization.yaml
@@ -20,14 +20,14 @@ patches:
 # `judge-server` 이미지는 자주 변경되지 않으므로 수동으로 설정합니다.
 images:
   - name: backend
-    newName: harbor.code-place-dev.site/code-place-dev/backend
+    newName: harbor.code-place-dev.kr/code-place-dev/backend
     newTag: 32ba295092fdc045029b8d772777fcf0368a6c0f-dev
   - name: frontend
-    newName: harbor.code-place-dev.site/code-place-dev/frontend
+    newName: harbor.code-place-dev.kr/code-place-dev/frontend
     newTag: 06c87027ba23b041855245e77212c44dc0bee124-dev
   - name: judge-server
-    newName: harbor.code-place-dev.site/code-place-dev/judge-server
+    newName: harbor.code-place-dev.kr/code-place-dev/judge-server
     newTag: 1.0.3
   - name: hub-auth
-    newName: harbor.code-place-dev.site/code-place-dev/hub-auth
+    newName: harbor.code-place-dev.kr/code-place-dev/hub-auth
     newTag: 644531052f1ef464fe902ce0522fcffeb2a76ee5-dev

--- a/kubernetes/overlays/prod/hub-auth-ingress-patch.yaml
+++ b/kubernetes/overlays/prod/hub-auth-ingress-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hub-auth-ingress
 spec:
   rules:
-    - host: hub-auth.code-place-dev.site
+    - host: hub-auth.code-place-dev.kr
       http:
         paths:
           - path: /
@@ -16,4 +16,4 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - hub-auth.code-place-dev.site
+        - hub-auth.code-place-dev.kr

--- a/kubernetes/overlays/prod/kustomization.yaml
+++ b/kubernetes/overlays/prod/kustomization.yaml
@@ -22,14 +22,14 @@ patches:
 # `judge-server` 이미지는 자주 변경되지 않으므로 수동으로 설정합니다.
 images:
   - name: backend
-    newName: harbor.code-place-dev.site/code-place-prod/backend
+    newName: harbor.code-place-dev.kr/code-place-prod/backend
     newTag: 57563df8c4de2a51ecb334180aa944d4a4d418d7-prod
   - name: frontend
-    newName: harbor.code-place-dev.site/code-place-prod/frontend
+    newName: harbor.code-place-dev.kr/code-place-prod/frontend
     newTag: 57563df8c4de2a51ecb334180aa944d4a4d418d7-prod
   - name: judge-server
-    newName: harbor.code-place-dev.site/code-place-prod/judge-server
+    newName: harbor.code-place-dev.kr/code-place-prod/judge-server
     newTag: 1.0.3
   - name: hub-auth
-    newName: harbor.code-place-dev.site/code-place-prod/hub-auth
+    newName: harbor.code-place-dev.kr/code-place-prod/hub-auth
     newTag: 57563df8c4de2a51ecb334180aa944d4a4d418d7-prod


### PR DESCRIPTION
## 도메인 마이그레이션

기존 `code-place-dev.site` 도메인이 만료되어 `code-place-dev.kr`로 교체합니다.

### 변경 대상 (19개 파일)
- 컨테이너 레지스트리 주소 (dev/prod kustomization) — 8곳
- Ingress host 및 TLS 도메인 — 6곳
- hub 인증 서버 주소 (`hub/scripts/*.js`) — 2곳
- 모니터링 알림 링크, probe 대상, Grafana ingress
- 레거시 docker-compose 파일

### 저장소 밖에서 함께 필요한 작업
1. 가비아 DNS A 레코드 8개 등록 (전부 `164.125.249.23`)
2. Harbor `hostname` 변경 및 재기동
3. GitHub Secret `HARBOR_REGISTRY` 수정
4. `regcred` imagePullSecret 재생성 (dev/prod)
5. 기존 이미지 새 주소로 재푸시
6. hub 연동 외부 사이트(패밀리사이트) 주소 변경 통보

TLS 인증서는 Traefik이 Let's Encrypt로 자동 발급하므로 별도 작업 없습니다.