### PR TITLE
fix: 쿠버네티스 매니페스트를 실제 배포 상태와 일치시킴

### DIFF
--- a/kubernetes/base/postgres/postgres.yaml
+++ b/kubernetes/base/postgres/postgres.yaml
@@ -18,8 +18,11 @@ spec:
       memory: 2Gi
 
   storage:
-    storageClass: longhorn-cnpg
-    size: 30Gi
+    # NOTE: CNPG 전용 storageClass(longhorn-cnpg, #761)로의 전환은 보류 중입니다.
+    # 기존 인스턴스의 PVC는 자동 이관되지 않아 별도 마이그레이션 계획이 필요하며,
+    # 우선 실제 배포 상태(longhorn)와 매니페스트를 일치시켜 apply가 반려되지 않게 합니다.
+    storageClass: longhorn
+    size: 50Gi
 
   bootstrap:
     initdb:

--- a/kubernetes/base/vllm/deployment.yaml
+++ b/kubernetes/base/vllm/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - --gpu-memory-utilization
             - "0.9"
             - --max-model-len
-            - "4096"
+            - "32768"
             - --max-num-batched-tokens
             - "4096"
             - --kv-cache-dtype

--- a/kubernetes/base/vllm/pvc.yaml
+++ b/kubernetes/base/vllm/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 30Gi
+      storage: 50Gi


### PR DESCRIPTION
## 매니페스트 드리프트 정리

`kubectl apply -k`가 반려되거나 의도치 않은 변경을 일으키던 항목을
실제 배포 상태와 일치시킵니다.

### 변경 내용

| 파일 | 항목 | 저장소(변경 전) | 실제 배포 | 변경 후 |
| --- | --- | --- | --- | --- |
| `base/vllm/deployment.yaml` | `--max-model-len` | 4096 | **32768** | 32768 |
| `base/vllm/pvc.yaml` | storage | 30Gi | **50Gi** | 50Gi |
| `base/postgres/postgres.yaml` | size | 30Gi | **50Gi** | 50Gi |
| `base/postgres/postgres.yaml` | storageClass | longhorn-cnpg | **longhorn** | longhorn (보류) |

### 배경

릴리즈 3.1.6 배포 중 `kubectl apply -k overlays/prod`가 아래 두 리소스를 반려했고,
vLLM에는 의도치 않은 변경이 포함되어 있었습니다.

- PVC 두 개는 운영 중 확장(30Gi → 50Gi)했으나 매니페스트에 반영되지 않아,
  적용 시 축소로 판단되어 반려되었습니다.
- vLLM `--max-model-len`은 배포본이 32768인데 매니페스트는 4096이었습니다.
  그대로 적용하면 컨텍스트 한도가 8배 축소되고 vLLM이 재시작됩니다.
  실측 힌트 요청 컨텍스트가 약 3,000 토큰이고 사용자 코드가 8,000자까지
  허용되므로 4096은 부족하다고 판단해 배포본 값(32768)을 정본으로 삼았습니다.

이 때문에 3.1.6 배포는 해당 리소스를 제외하고 진행했습니다.
이 PR 이후에는 `apply -k`가 정상 동작합니다.

### storageClass 보류 사유

`#761`이 도입한 CNPG 전용 storageClass(`longhorn-cnpg`) 전환은 이번 PR에서 제외했습니다.

`--dry-run=server`로 확인한 결과 CNPG가 이 변경을 **수용**합니다
(`cluster.postgresql.cnpg.io/postgres configured`).
그러나 기존 인스턴스의 PVC는 자동 이관되지 않으므로, 신규 인스턴스부터
다른 storageClass를 쓰게 되어 클래스가 혼재합니다.

운영 DB 스토리지 정책 변경이므로 별도 마이그레이션 계획이 필요하다고 판단했습니다.
`longhorn-cnpg` StorageClass 정의 자체는 그대로 두었으므로,
계획이 서면 그때 전환하면 됩니다.

**@#761 작성자** 전환 시점과 방식 확인 부탁드립니다.