### PR TITLE
fix: 운영 postgres 설정을 실제 배포 상태에 맞춰 prod overlay에 고정

### DIFF
--- a/kubernetes/overlays/prod/kustomization.yaml
+++ b/kubernetes/overlays/prod/kustomization.yaml
@@ -17,6 +17,12 @@ patches:
   - path: judge-server-deployment-patch.yaml
   - path: hub-auth-deployment-patch.yaml
   - path: hub-auth-ingress-patch.yaml
+  - path: postgres-cluster-patch.yaml
+    target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster
+      name: postgres
 # NOTE: base 디렉토리의 이미지 이름과 태그를 오버라이드합니다.
 # `backend`, `frontend`, `hub-auth` 이미지 태그는 CI 파이프라인에서 자동으로 변경됩니다.
 # `judge-server` 이미지는 자주 변경되지 않으므로 수동으로 설정합니다.

--- a/kubernetes/overlays/prod/postgres-cluster-patch.yaml
+++ b/kubernetes/overlays/prod/postgres-cluster-patch.yaml
@@ -1,0 +1,11 @@
+# 운영 DB의 실제 설정을 매니페스트에 반영합니다.
+#
+# - resources: 운영 클러스터는 제한 없이 동작 중입니다. base의 메모리 상한(2Gi)은
+#   실사용량(약 1.2Gi)에 비해 여유가 적어 OOM 위험이 있으므로 prod에서는 제거합니다.
+# - primaryUpdateStrategy: 운영 DB는 primary 교체를 수동 승인(supervised)으로 운영합니다.
+#   자동 switchover는 예기치 않은 시점에 primary가 바뀔 수 있어 prod에서는 사용하지 않습니다.
+- op: remove
+  path: /spec/resources
+- op: replace
+  path: /spec/primaryUpdateStrategy
+  value: supervised


### PR DESCRIPTION
# Changelog

`kubectl apply -k overlays/prod` 시 운영 DB에 의도치 않은 변경이 나가던 항목을
prod overlay 패치로 고정.

릴리즈 3.1.6 배포 중 `apply -k`가 운영 DB에 두 가지 미검증 변경을 포함하는 것을 확인해
해당 리소스를 제외하고 배포.

- **`resources`**: 운영 DB 실사용량이 약 1.2Gi인데 base 상한이 2Gi로 여유가 적어
  OOM 위험이 있습니다. 현재 운영은 제한 없이 동작 중이므로 prod에서는 제거합니다.
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
-
<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
-
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
-
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
