### PR TITLE
fix: dev postgres 인스턴스 수를 실제 배포 상태(2개)로 고정

### DIFF
--- a/kubernetes/overlays/dev/kustomization.yaml
+++ b/kubernetes/overlays/dev/kustomization.yaml
@@ -15,6 +15,12 @@ patches:
   - path: celery-beat-deployment-patch.yaml
   - path: judge-server-deployment-patch.yaml
   - path: hub-auth-ingress-patch.yaml
+  - path: postgres-cluster-patch.yaml
+    target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster
+      name: postgres
 # NOTE: base 디렉토리의 이미지 이름과 태그를 오버라이드합니다.
 # `backend`, `frontend`, `hub-auth` 이미지 태그는 CI 파이프라인에서 자동으로 변경됩니다.
 # `judge-server` 이미지는 자주 변경되지 않으므로 수동으로 설정합니다.

--- a/kubernetes/overlays/dev/postgres-cluster-patch.yaml
+++ b/kubernetes/overlays/dev/postgres-cluster-patch.yaml
@@ -1,0 +1,7 @@
+# 개발 환경의 실제 운영 상태를 매니페스트에 반영합니다.
+#
+# - instances: dev는 복제본 2개로 운영합니다. base의 3개를 그대로 적용하면
+#   인스턴스가 하나 더 생성되며 50Gi PVC가 추가로 잡힙니다.
+- op: replace
+  path: /spec/instances
+  value: 2


### PR DESCRIPTION
# Changelog

`kubectl apply -k overlays/dev` 시 postgres 인스턴스가 늘어나던 문제를 정리합니다.

| 항목 | 실제 dev | base | dev overlay |
| --- | --- | --- | --- |
| `instances` | 2 | 3 | **2** |

base의 3개를 그대로 적용하면 인스턴스가 하나 더 생성되고 50Gi PVC가 추가로 잡힙니다.
dev는 복제본 2개로 운영 중이므로 실제 상태를 매니페스트에 반영합니다.

<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact

<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
