### PR TITLE
fix: dev postgres resources를 실제 배포 상태에 맞춰 제거

### DIFF
--- a/kubernetes/overlays/dev/postgres-cluster-patch.yaml
+++ b/kubernetes/overlays/dev/postgres-cluster-patch.yaml
@@ -2,6 +2,10 @@
 #
 # - instances: dev는 복제본 2개로 운영합니다. base의 3개를 그대로 적용하면
 #   인스턴스가 하나 더 생성되며 50Gi PVC가 추가로 잡힙니다.
+# - resources: dev/prod 모두 제한 없이 동작 중입니다. 리소스 제한은 두 환경에서
+#   같은 기준으로 정해야 하므로, 지금은 실제 상태를 반영해 제거만 해둡니다.
 - op: replace
   path: /spec/instances
   value: 2
+- op: remove
+  path: /spec/resources


### PR DESCRIPTION
# Changelog

`kubectl apply -k overlays/dev`가 dev DB에 메모리 상한(2Gi)을 새로 거는 것을 확인해,
실제 배포 상태(제한 없음)를 매니페스트에 반영합니다.

| 항목 | 실제 dev | base | dev overlay |
| --- | --- | --- | --- |
| `instances` | 2 | 3 | 2 |
| `resources` | 제한 없음 | cpu 250m-2, mem 512Mi-2Gi | **제거** |

dev 실사용량은 111~182Mi로 2Gi 상한에 여유가 있으나,
prod가 이미 `resources` 제거로 정리된 상태이므로 두 환경의 방침을 통일합니다.
리소스 제한은 prod/dev 같은 기준으로 별도 논의해 정하는 것이 맞다고 판단했습니다.
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact

<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
