### PR TITLE
#781 fix: 문제 목록 최신순 정렬 및 new태그 추가 

### DIFF
--- a/backend/problem/serializers.py
+++ b/backend/problem/serializers.py
@@ -1,6 +1,8 @@
 import re
+from datetime import timedelta
 
 from django import forms
+from django.utils import timezone
 
 from options.options import SysOptions
 from utils.api import UsernameSerializer, serializers
@@ -9,6 +11,9 @@ from utils.serializers import LanguageNameMultiChoiceField, SPJLanguageNameChoic
 
 from .models import Problem, ProblemRuleType, ProblemTag, ProblemIOMode, ProblemDifficulty, ProblemAIHintLog
 from .utils import parse_problem_template
+
+# 등록 후 신규 문제(NEW 태그)로 표시할 기간 (일 단위)
+NEW_PROBLEM_DAYS = 7
 
 
 class AIHintLogSerializer(serializers.ModelSerializer):
@@ -130,11 +135,18 @@ class ProblemAdminSerializer(BaseProblemSerializer):
 class ProblemSerializer(BaseProblemSerializer):
     template = serializers.SerializerMethodField("get_public_template")
     mine_submission_state = serializers.SerializerMethodField(default=None)
+    is_new = serializers.SerializerMethodField()
 
     class Meta:
         model = Problem
         exclude = ("test_case_score", "test_case_id", "visible", "is_public", "spj_code", "spj_version",
                    "spj_compile_ok")
+
+    def get_is_new(self, obj):
+        # 생성 후 NEW_PROBLEM_DAYS(7일) 이내인 경우 신규 문제(True)로 판별
+        if not obj.create_time:
+            return False
+        return (timezone.now() - obj.create_time) <= timedelta(days=NEW_PROBLEM_DAYS)
 
     def get_mine_submission_state(self, obj):
         if not self.context:

--- a/backend/problem/tests.py
+++ b/backend/problem/tests.py
@@ -241,6 +241,58 @@ class ProblemAPITest(ProblemCreateTestBase):
         resp = self.client.get(f"{self.url}?limit=10")
         self.assertSuccess(resp)
 
+    def test_get_problem_list_default_sort_by_create_time_desc(self):
+        """정렬 옵션이 없을 때 기본적으로 최신 등록순으로 정렬되는지 검증"""
+        newer_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-999",
+            title="newer problem",
+        )
+        resp = self.client.get(f"{self.url}?limit=10")
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], newer_problem._id)
+        self.assertEqual(results[1]["_id"], self.problem._id)
+
+    def test_get_problem_list_sort_by_id(self):
+        """문제 번호(#) 헤더 클릭 시 id_desc(최신순), id_asc(오래된순) 정렬 검증"""
+        newer_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-999",
+            title="newer problem",
+        )
+        # id_desc (newest first)
+        resp = self.client.get(f"{self.url}?limit=10&sort=id_desc")
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], newer_problem._id)
+
+        # id_asc (oldest first)
+        resp = self.client.get(f"{self.url}?limit=10&sort=id_asc")
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], self.problem._id)
+
+    def test_problem_is_new_badge(self):
+        """등록 7일 이내 문제는 is_new=True, 기간 경과 문제는 is_new=False 반환 검증"""
+        from datetime import timedelta
+        from django.utils import timezone
+
+        # self.problem was just created -> is_new True
+        resp = self.client.get(f"{self.url}?limit=10")
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertTrue(results[0]["is_new"])
+
+        # simulate an old problem created 10 days ago
+        self.problem.create_time = timezone.now() - timedelta(days=10)
+        self.problem.save(update_fields=["create_time"])
+
+        resp = self.client.get(f"{self.url}?limit=10")
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertFalse(results[0]["is_new"])
+
     def test_get_problem_list_sort_by_accepted_number(self):
         self.problem.accepted_number = 2
         self.problem.submission_number = 10

--- a/backend/problem/views/oj.py
+++ b/backend/problem/views/oj.py
@@ -92,6 +92,10 @@ class ProblemAPI(APIView):
     }
 
     SORT_FIELDS = {
+        "id_desc": ("-create_time", "-_id"),
+        "id_asc": ("create_time", "_id"),
+        "create_time_desc": ("-create_time", "-_id"),
+        "create_time_asc": ("create_time", "_id"),
         "difficulty_asc": ("difficulty_order", "_id"),
         "difficulty_desc": ("-difficulty_order", "_id"),
         "accepted_desc": ("-accepted_number", "_id"),
@@ -179,6 +183,9 @@ class ProblemAPI(APIView):
                     output_field=FloatField(),
                 ),
             ).order_by(*self.SORT_FIELDS[sort])
+        else:
+            # 문제 기본 정렬: 최신 등록일 내림차순 (동일 일시일 경우 ID 내림차순)
+            problems = problems.order_by("-create_time", "-_id")
 
         # 根据profile 为做过的题目添加标记
         data = self.paginate_data(request, problems, ProblemSerializer)

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
@@ -2,7 +2,17 @@
   <table>
     <thead>
       <tr>
-        <th class="th-first">{{ $t("m.Th_Problem_Id") }}</th>
+        <!-- 문제 번호(#) 헤더: 클릭 시 최신순 ↔ 오래된순 토글 정렬 -->
+        <th class="th-first">
+          <button
+            type="button"
+            class="sort-header-button"
+            @click="changeSort('id')"
+          >
+            {{ $t("m.Th_Problem_Id") }}
+            <i :class="sortIconClass('id')"></i>
+          </button>
+        </th>
         <th class="th-second">{{ $t("m.Th_Problem_Title") }}</th>
         <th class="th-third">
           <button
@@ -75,6 +85,8 @@
             <span class="problemTitle">
               {{ problem.title }}
             </span>
+            <!-- 최근 7일 이내 등록된 신규 문제 NEW 뱃지 -->
+            <span v-if="problem.is_new" class="badge-new">NEW</span>
             <br />
             <div v-if="showTags" class="problem-meta-row">
               <FieldCategoryBox
@@ -331,6 +343,22 @@ tbody {
 
     .problemTitle:hover {
       color: #4a86c0;
+    }
+
+    /* 공지사항과 동일한 그린 톤의 신규 문제 NEW 뱃지 */
+    .badge-new {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      color: #16a34a;
+      background-color: #dcfce7;
+      border-radius: 6px;
+      padding: 2px 7px;
+      margin-left: 6px;
+      letter-spacing: 0.3px;
+      white-space: nowrap;
+      vertical-align: middle;
+      user-select: none;
     }
 
     .problem-meta-row {

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
@@ -82,12 +82,13 @@
             class="td-second"
             @click="enterProblemDetail(problem._id, problem.title)"
           >
-            <span class="problemTitle">
-              {{ problem.title }}
-            </span>
-            <!-- 최근 7일 이내 등록된 신규 문제 NEW 뱃지 -->
-            <span v-if="problem.is_new" class="badge-new">NEW</span>
-            <br />
+            <div class="problem-title-wrapper">
+              <span class="problemTitle">
+                {{ problem.title }}
+              </span>
+              <!-- 최근 7일 이내 등록된 신규 문제 NEW 뱃지 -->
+              <span v-if="problem.is_new" class="badge-new">NEW</span>
+            </div>
             <div v-if="showTags" class="problem-meta-row">
               <FieldCategoryBox
                 :boxType="true"
@@ -335,10 +336,19 @@ tbody {
       text-align: center;
     }
 
+    .problem-title-wrapper {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 6px;
+      vertical-align: middle;
+    }
+
     .problemTitle {
       font-weight: bold;
       cursor: pointer;
       font-size: medium;
+      line-height: 1.4;
     }
 
     .problemTitle:hover {
@@ -347,17 +357,18 @@ tbody {
 
     /* 공지사항과 동일한 그린 톤의 신규 문제 NEW 뱃지 */
     .badge-new {
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       font-size: 10px;
       font-weight: 700;
       color: #16a34a;
       background-color: #dcfce7;
       border-radius: 6px;
       padding: 2px 7px;
-      margin-left: 6px;
+      line-height: 1.2;
       letter-spacing: 0.3px;
       white-space: nowrap;
-      vertical-align: middle;
       user-select: none;
     }
 


### PR DESCRIPTION
refer #781 

# Changelog
### 문제 목록 정렬 순서를 최신순으로 변경
- 문제 탭 진입 시 기존의 오래된 순서 대신, 최근에 등록된 문제부터 우선적으로 노출되도록 기본 정렬을 변경
- 새로 등록된 과제나 문제를 사용자가 1페이지에서 바로 확인할 수 있습니다.

### 표 header의 문제 번호에 정렬 토글 기능 추가
- 문제 목록 표의 문제 번호(#) 헤더를 클릭하여 최신순 <-> 오래된순으로 순환 정렬할 수 있는 기능 추가

### 최신 문제(7일 이내에 생성된) 에 new 태그 추가
- 등록된 지 7일 이내인 신규 문제의 경우 제목 옆에 공지사항과 동일한 스타일의 초록색 NEW 태그가 표시되도록 구현

<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
### **단위 테스트**
  - 기본 목록 조회가 최신순으로 정렬되어 반환되는지 검증
  - 문제 번호 헤더를 통한 최신순/오래된순 정렬이 정상 작동하는지 검증
  - 등록 7일 이내 문제에만 NEW 태그가 정상 부여되는지 검증

### **로컬 수동 테스트**
  - 테스트 문제 데이터를 생성하여 브라우저에서 검증 
  - 목록 진입 시 최신 등록 문제가 맨 위에 노출되는지 확인
  - 문제 번호 헤더 클릭 시 정렬 순서가 뒤집히는지 확인
  - 7일 이내 문제에만 NEW 태그가 정상 표시되고 지난 문제는 안 뜨는지 확인
<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
