### PR TITLE
fix: 문제 목록 테이블 정렬 시 컬럼 레이아웃 고정

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
@@ -255,6 +255,7 @@ table {
   border-radius: 7px;
   border-spacing: 0;
   overflow: hidden;
+  table-layout: fixed;
 }
 table:hover {
   border: 1px solid #cccccc;
@@ -302,13 +303,27 @@ thead {
   color: #7e7e7e;
 
   .th-first {
-    white-space: normal;
-    word-break: normal;
-    overflow-wrap: break-word;
+    width: 13%;
+    white-space: nowrap;
   }
 
   .th-second {
-    width: 400px;
+    width: 45%;
+  }
+
+  .th-third {
+    width: 14%;
+    white-space: nowrap;
+  }
+
+  .th-fourth {
+    width: 14%;
+    white-space: nowrap;
+  }
+
+  .th-fifth {
+    width: 14%;
+    white-space: nowrap;
   }
 }
 
@@ -322,9 +337,7 @@ tbody {
     }
 
     .td-first {
-      white-space: normal;
-      word-break: normal;
-      overflow-wrap: break-word;
+      white-space: nowrap;
     }
 
     td:nth-child(2) {


### PR DESCRIPTION
# Changelog
### 문제 목록 표 컬럼 너비 및 간격 고정
- 정렬을 변경하거나 페이지를 넘길 때 데이터 길이에 따라 표의 열 간격이 제각각 흔들리던 문제를 수정
- 최신순/오래된순 등 어떤 정렬 상태에서도 동일한 표 간격이 유지되도록 레이아웃을 고정
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
local test 완료
<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
